### PR TITLE
Removed PKCS#5 v2.0 algorithm reference

### DIFF
--- a/pages/configuration/https.rst
+++ b/pages/configuration/https.rst
@@ -52,9 +52,9 @@ Convert PKCS#5 private key into a *plaintext* PKCS#8 private key::
 
   $ openssl pkcs8 -in pkcs5-plain.pem -topk8 -nocrypt -out pkcs8-plain.pem
 
-Convert PKCS#5 private key into an *encrypted* PKCS#8 private key (using DES3 and the passphrase ``secret``)::
+Convert PKCS#5 private key into an *encrypted* PKCS#8 private key (using the passphrase ``secret``)::
 
-  $ openssl pkcs8 -in pkcs5-plain.pem -topk8 -v2 des3 -out pkcs8-encrypted.pem -passout pass:secret
+  $ openssl pkcs8 -in pkcs5-plain.pem -topk8 -out pkcs8-encrypted.pem -passout pass:secret
 
 
 Converting an existing Java Keystore to private key/certificate pair


### PR DESCRIPTION
**Description:**
`-v2 <alg>` appears to be a PKCS#5 option. Running the conversion command with this option outputs a PKCS#5 file, and the Graylog server will fail to start, showing the stack traces below in `server.log`.

```
2016-06-16T20:48:53.343Z ERROR [ServiceManager] Service IndexerSetupService [FAILED] has failed in the STOPPING state.
java.lang.IllegalStateException: Can't move to started state when closed
    at org.elasticsearch.common.component.Lifecycle.moveToStarted(Lifecycle.java:130) ~[graylog.jar:?]
    at org.elasticsearch.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:69) ~[graylog.jar:?]
    at org.elasticsearch.transport.TransportService.doStart(TransportService.java:182) ~[graylog.jar:?]
    at org.elasticsearch.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:68) ~[graylog.jar:?]
    at org.elasticsearch.node.Node.start(Node.java:278) ~[graylog.jar:?]
    at org.graylog2.initializers.IndexerSetupService.startUp(IndexerSetupService.java:114) ~[graylog.jar:?]
    at com.google.common.util.concurrent.AbstractIdleService$DelegateService$1.run(AbstractIdleService.java:60) [graylog.jar:?]
    at com.google.common.util.concurrent.Callables$3.run(Callables.java:100) [graylog.jar:?]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_91]
2016-06-16T20:48:53.357Z INFO  [LogManager] Shutdown complete.
2016-06-16T20:48:53.390Z INFO  [JournalReader] Stopping.
2016-06-16T20:48:53.453Z INFO  [AbstractJerseyService] Enabling CORS for HTTP endpoint
2016-06-16T20:48:53.456Z ERROR [ServiceManager] Service RestApiService [FAILED] has failed in the STOPPING state.
java.io.IOException: ObjectIdentifier() -- data isn't an object ID (tag = 48)
    at sun.security.util.ObjectIdentifier.<init>(ObjectIdentifier.java:253) ~[?:1.8.0_91]
    at sun.security.util.DerInputStream.getOID(DerInputStream.java:281) ~[?:1.8.0_91]
    at com.sun.crypto.provider.PBES2Parameters.engineInit(PBES2Parameters.java:267) ~[sunjce_provider.jar:1.8.0_71]
    at java.security.AlgorithmParameters.init(AlgorithmParameters.java:293) ~[?:1.8.0_91]
    at sun.security.x509.AlgorithmId.decodeParams(AlgorithmId.java:132) ~[?:1.8.0_91]
    at sun.security.x509.AlgorithmId.<init>(AlgorithmId.java:114) ~[?:1.8.0_91]
    at sun.security.x509.AlgorithmId.parse(AlgorithmId.java:372) ~[?:1.8.0_91]
    at javax.crypto.EncryptedPrivateKeyInfo.<init>(EncryptedPrivateKeyInfo.java:95) ~[?:1.8.0_71]
    at org.graylog2.shared.security.tls.PemKeyStore.generateKeySpec(PemKeyStore.java:69) ~[graylog.jar:?]
    at org.graylog2.shared.security.tls.PemKeyStore.buildKeyStore(PemKeyStore.java:96) ~[graylog.jar:?]
    at org.graylog2.shared.initializers.AbstractJerseyService.buildSslEngineConfigurator(AbstractJerseyService.java:187) ~[graylog.jar:?]
    at org.graylog2.shared.initializers.AbstractJerseyService.setUp(AbstractJerseyService.java:158) ~[graylog.jar:?]
    at org.graylog2.shared.initializers.RestApiService.startUp(RestApiService.java:65) ~[graylog.jar:?]
    at com.google.common.util.concurrent.AbstractIdleService$DelegateService$1.run(AbstractIdleService.java:60) [graylog.jar:?]
    at com.google.common.util.concurrent.Callables$3.run(Callables.java:100) [graylog.jar:?]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_91]
2016-06-16T20:48:53.457Z INFO  [ServiceManagerListener] Services are now stopped.
2016-06-16T20:48:53.457Z WARN  [DeadEventLoggingListener] Received unhandled event of type <org.graylog2.plugin.lifecycles.Lifecycle> from event bus <AsyncEventBus{graylog-eventbus}>
2016-06-16T20:48:53.457Z ERROR [ServerBootstrap] Graylog startup failed. Exiting. Exception was:
java.lang.IllegalStateException: Expected to be healthy after starting. The following services are not running: {STARTING=[RestApiService [STARTING], IndexerSetupService [STARTING]], FAILED=[WebInterfaceService [FAILED]]}
    at com.google.common.util.concurrent.ServiceManager$ServiceManagerState.checkHealthy(ServiceManager.java:713) ~[graylog.jar:?]
    at com.google.common.util.concurrent.ServiceManager$ServiceManagerState.awaitHealthy(ServiceManager.java:542) ~[graylog.jar:?]
    at com.google.common.util.concurrent.ServiceManager.awaitHealthy(ServiceManager.java:299) ~[graylog.jar:?]
    at org.graylog2.bootstrap.ServerBootstrap.startCommand(ServerBootstrap.java:129) [graylog.jar:?]
    at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:209) [graylog.jar:?]
    at org.graylog2.bootstrap.Main.main(Main.java:44) [graylog.jar:?]
2016-06-16T20:48:53.459Z INFO  [Server] SIGNAL received. Shutting down.
```

**References**
[https://www.openssl.org/docs/manmaster/apps/pkcs8.html](https://www.openssl.org/docs/manmaster/apps/pkcs8.html)

```
$ openssl pkcs8 --help
Usage pkcs8 [options]
where options are
...
-v2 alg         use PKCS#5 v2.0 and cipher "alg"
```
