### PR TITLE
Change the ansible url

### DIFF
--- a/pages/installation/config_management_tools.rst
+++ b/pages/installation/config_management_tools.rst
@@ -8,7 +8,7 @@ all three of them:
 
 * https://supermarket.chef.io/cookbooks/graylog2
 * https://forge.puppet.com/graylog/graylog
-* https://galaxy.ansible.com/list#/roles/3162
+* https://galaxy.ansible.com/Graylog2/graylog-ansible-role
 
 There are also official `Vagrant <https://www.vagrantup.com>`_ images if you want to spin up a local virtual machine quickly:
 


### PR DESCRIPTION
For 2.0 the ansible galaxy role is now at https://galaxy.ansible.com/Graylog2/graylog-ansible-role
