### PR TITLE
Add the 'share' directory to '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ _build
 [Ll]ib64
 [Ll]ocal
 [Ss]cripts
+share
 pyvenv.cfg
 .venv
 pip-selfcheck.json
-share

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _build
 pyvenv.cfg
 .venv
 pip-selfcheck.json
+share


### PR DESCRIPTION
When initializing a new virtualenv on a Debian-based system 'wheels' binary packages are stored in `<VIRTUAL_ENV>/share/python-wheels`.  This PR simply adds the 'share' directory to '.gitignore'.

**Reference:** Section 3.2 of https://www.debian.org/doc/packaging-manuals/python-policy/ch-module_packages.html
