### PR TITLE
Update URI/network defaults for Graylog 2.1.x

### DIFF
--- a/pages/archiving/usage.rst
+++ b/pages/archiving/usage.rst
@@ -57,7 +57,7 @@ do this.
 
 An index can be archived with a simple curl command::
 
-   $ curl -s -u admin -X POST http://127.0.0.1:12900/plugins/org.graylog.plugins.archive/archives/graylog_386
+   $ curl -s -u admin -X POST http://127.0.0.1:9000/api/plugins/org.graylog.plugins.archive/archives/graylog_386
    Enter host password for user 'admin': ***************
    {
       "archive_job_config" : {
@@ -133,7 +133,7 @@ REST API
 As with archive creation you can also use the REST API to restore an
 archived index into the Elasticsearch cluster::
 
-   $ curl -s -u admin -X POST http://127.0.0.1:12900/plugins/org.graylog.plugins.archive/archives/graylog_386/restore
+   $ curl -s -u admin -X POST http://127.0.0.1:9000/api/plugins/org.graylog.plugins.archive/archives/graylog_386/restore
    Enter host password for user 'admin': ***************
    {
       "archive_metadata": {

--- a/pages/collector.rst
+++ b/pages/collector.rst
@@ -100,7 +100,7 @@ Replace the ``<your-graylog-server-ip>`` with the IP address of your Graylog ser
 
 Example::
 
-  server-url = "http://<your-graylog-server-ip>:12900/"
+  server-url = "http://<your-graylog-server-ip>:9000/api/"
 
   inputs {
     win-eventlog-application {
@@ -147,7 +147,7 @@ If you choose the operating system installation method, the configuration file d
 
 Here is a minimal configuration example that collects logs from the ``/var/log/syslog`` file and sends them to a Graylog server::
 
-  server-url = "http://10.0.0.1:12900/"
+  server-url = "http://10.0.0.1:9000/api/"
 
   inputs {
     syslog {
@@ -172,7 +172,7 @@ Global Settings
 ``server-url`` - The API URL of the Graylog server
   Used to send a heartbeat to the Graylog server.
 
-  (default: ``"http://localhost:12900"``)
+  (default: ``"http://localhost:9000/api/"``)
 ``enable-registration`` - Enable heartbeat registration
   Enables the heartbeat registration with the Graylog server. The collector will not contact the Graylog server API for heartbeat registration if this is set to ``false``.
 
@@ -634,12 +634,12 @@ Unable to send heartbeat
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The collector registers with your Graylog server on a regular basis to make sure it shows up on the Collectors page in the Graylog web interface.
-This registration can fail if the collector cannot connect to the server via HTTP on port ``12900``::
+This registration can fail if the collector cannot connect to the server via HTTP on port ``9000``::
 
   2015-06-06T10:45:14.964+0200 WARN  [HeartbeatService RUNNING] collector.heartbeat.HeartbeatService - Unable to send heartbeat to Graylog server: ConnectException: Connection refused
 
 **Possible solutions**
 
 * Make sure the server REST API is configured to listen on a reachable IP address.
-  Change the "rest_listen_uri" setting in the Graylog server config to this: ``rest_listen_uri = http://0.0.0.0:12900/``
-* Correctly configure any firewalls between the collector and the server to allow HTTP traffic to port ``12900``.
+  Change the "rest_listen_uri" setting in the Graylog server config to this: ``rest_listen_uri = http://0.0.0.0:9000/api/``
+* Correctly configure any firewalls between the collector and the server to allow HTTP traffic to port ``9000``.

--- a/pages/collector_sidecar.rst
+++ b/pages/collector_sidecar.rst
@@ -147,7 +147,7 @@ The configuration file is separated into global options and backend specific opt
 +-------------------+---------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter         | Description                                                                                                                           |
 +===================+=======================================================================================================================================+
-| server_url        | URL to the Graylog API, e.g. ``http://127.0.0.1:12900``                                                                               |
+| server_url        | URL to the Graylog API, e.g. ``http://127.0.0.1:9000/api/``                                                                           |
 +-------------------+---------------------------------------------------------------------------------------------------------------------------------------+
 | update_interval   | The interval in seconds the sidecar will fetch new configurations from the Graylog server                                             |
 +-------------------+---------------------------------------------------------------------------------------------------------------------------------------+
@@ -189,7 +189,7 @@ write a configuration file for it.
 
 An example configuration for NXlog looks like this::
 
-    server_url: http://10.0.2.2:12900
+    server_url: http://10.0.2.2:9000/api/
     update_interval: 30
     tls_skip_verify: true
     send_status: true
@@ -212,7 +212,7 @@ An example configuration for NXlog looks like this::
 
 For the Beats platform you can enable each Beat individually, e.g on a Windows host with Filebeat and Winlogbeat enabled use a configuration like this::
 
-    server_url: http://10.0.2.2:12900
+    server_url: http://10.0.2.2:9000/api/
     update_interval: 30
     tls_skip_verify: true
     send_status: true

--- a/pages/configuration/web_interface.rst
+++ b/pages/configuration/web_interface.rst
@@ -20,7 +20,7 @@ Single or separate listeners for web interface and REST API?
 Since Graylog 2.1 you have two options when it comes to exposing its web interface:
 
  - Running both on the same port, using different paths (defaulting to ``http://localhost:9000/api/`` for the REST API and ``http://localhost:9000/`` for the web interface), this is the default since 2.1 and is assumed for most parts of the documentation.
- - Running on two different ports (for example ``http://localhost:9000/api/`` for the REST API and ``http://localhost:9000`` for the web interface)
+ - Running on two different ports (for example ``http://localhost:12900/`` for the REST API and ``http://localhost:9000/`` for the web interface)
  
 .. note:: When you are using the first option and you want to run the REST API and the web interface on the same host and port, the path part of both URIs (``rest_listen_uri`` & ``web_listen_uri``) must be different and the path part of ``web_listen_uri`` must be non-empty and different than ``/``.
 

--- a/pages/configuration/web_interface.rst
+++ b/pages/configuration/web_interface.rst
@@ -4,7 +4,7 @@
 Web interface
 *************
 
-When your Graylog instance/cluster is up and running, the next thing you usually want to do is check out our web interface, which offers you great capabilities for searching and analyzing your indexed data and configuring your Graylog environment. Per default you can access it using your browser on ``http://<graylog-server>:12900``.
+When your Graylog instance/cluster is up and running, the next thing you usually want to do is check out our web interface, which offers you great capabilities for searching and analyzing your indexed data and configuring your Graylog environment. Per default you can access it using your browser on ``http://<graylog-server>:9000/api/``.
 
 
 Overview
@@ -19,8 +19,8 @@ Single or separate listeners for web interface and REST API?
 
 Since Graylog 2.1 you have two options when it comes to exposing its web interface:
 
- - Running both on the same port, using different paths (defaulting to ``http://localhost:12900/`` for the REST API and ``http://localhost:12900/web`` for the web interface), this is the default since 2.1 and is assumed for most parts of the documentation.
- - Running on two different ports (for example ``http://localhost:12900`` for the REST API and ``http://localhost:9000`` for the web interface)
+ - Running both on the same port, using different paths (defaulting to ``http://localhost:9000/api/`` for the REST API and ``http://localhost:9000/`` for the web interface), this is the default since 2.1 and is assumed for most parts of the documentation.
+ - Running on two different ports (for example ``http://localhost:9000/api/`` for the REST API and ``http://localhost:9000`` for the web interface)
  
 .. note:: When you are using the first option and you want to run the REST API and the web interface on the same host and port, the path part of both URIs (``rest_listen_uri`` & ``web_listen_uri``) must be different and the path part of ``web_listen_uri`` must be non-empty and different than ``/``.
 
@@ -34,7 +34,7 @@ If our default settings do not work for you, there is a number of options in the
 +=========================+=================================+======================================================================+
 | ``web_enable``          | true                            | Determines if the web interface endpoint is started or not.          |
 +-------------------------+---------------------------------+----------------------------------------------------------------------+
-| ``web_listen_uri``      | http://127.0.0.1:12900/web      | Default address the web interface listener binds to.                 |
+| ``web_listen_uri``      | http://127.0.0.1:9000/          | Default address the web interface listener binds to.                 |
 +-------------------------+---------------------------------+----------------------------------------------------------------------+
 | ``web_endpoint_uri``    | If not set,                     | This is the external address of the REST API of the Graylog server.  |
 |                         | ``rest_transport_uri``          | Web interface clients need to be able to connect to this for the web |
@@ -115,14 +115,14 @@ If you want to run a load balancer/reverse proxy in front of Graylog, you need t
   - You are either using only HTTP or only HTTPS (no mixed content) for both the web interface endpoint and the REST API endpoint.
   - If you use SSL, your certificates must be valid and trusted by your clients.
 
-.. NOTE:: To help you with your specific environment, we have some example configurations. We take the following assumption in all examples. Your Graylog server.conf has the following settings set ``rest_listen_uri = http://127.0.0.1:12900/`` and ``web_listen_uri = http://127.0.0.1:9000/``. Your URL will be ``graylog.example.org`` with the IP ``192.168.0.10``.
+.. NOTE:: To help you with your specific environment, we have some example configurations. We take the following assumption in all examples. Your Graylog server.conf has the following settings set ``rest_listen_uri = http://127.0.0.1:9000/api/`` and ``web_listen_uri = http://127.0.0.1:9000/``. Your URL will be ``graylog.example.org`` with the IP ``192.168.0.10``.
 
 
 Using a Layer 3 load balancer (forwarding TCP Ports)
 ----------------------------------------------------
 
-#. Configure your load balancer to forward connections going to ``192.168.0.10:80`` to ``127.0.0.1:9000`` (``web_listen_uri``) and ``192.168.0.10:12900`` to ``127.0.0.1:12900`` (``rest_listen_uri``).
-#. Set ``web_endpoint_uri`` in your Graylog server config to ``http://graylog.example.org:12900``.
+#. Configure your load balancer to forward connections going to ``192.168.0.10:80`` to ``127.0.0.1:9000`` (``web_listen_uri``) and ``192.168.0.10:9000/api/`` to ``127.0.0.1:9000/api/`` (``rest_listen_uri``).
+#. Set ``web_endpoint_uri`` in your Graylog server config to ``http://graylog.example.org:9000/api/``.
 #. Start the Graylog server as usual.
 #. Access the web interface on ``http://graylog.example.org``.
 #. Read up on :ref:`ssl_setup`.
@@ -144,7 +144,7 @@ NGINX
             proxy_set_header    X-Forwarded-Host $host;
             proxy_set_header    X-Forwarded-Server $host;
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_pass          http://127.0.0.1:12900/;
+            proxy_pass          http://127.0.0.1:9000/api/;
         }
       location /
         {
@@ -168,7 +168,7 @@ NGINX
     location /
         {
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header    X-Graylog-Server-URL http://graylog.example.org:12900;
+            proxy_set_header    X-Graylog-Server-URL http://graylog.example.org:9000/api/;
             proxy_set_header    Host $http_host;
             proxy_pass          http://127.0.0.1:9000;
         }
@@ -176,14 +176,14 @@ NGINX
 
     server
     {
-        listen      12900;
+        listen      9000;
         server_name graylog.example.org;
 
     location /
         {
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header    Host $http_host;
-            proxy_pass          http://127.0.0.1:12900/;
+            proxy_pass          http://127.0.0.1:9000/api/;
         }
     }
 
@@ -211,7 +211,7 @@ If you are running multiple Graylog Server you might want to use HTTPS/SSL to co
         {
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header    Host $http_host;
-            proxy_pass          http://127.0.0.1:12900/;
+            proxy_pass          http://127.0.0.1:9000/api/;
         }
     }
 
@@ -228,8 +228,8 @@ Apache httpd 2.x
             Allow from all
         </Proxy>
         <Location /api/>
-            ProxyPass http://127.0.0.1:12900/
-            ProxyPassReverse http://127.0.0.1:12900/
+            ProxyPass http://127.0.0.1:9000/api/
+            ProxyPassReverse http://127.0.0.1:9000/api/
         </Location>
         <Location />
             RequestHeader set X-Graylog-Server-URL "http://graylog.example.org/api/"
@@ -264,5 +264,5 @@ HAProxy 1.6
         http-request set-header X-Graylog-Server-URL http://graylog.example.org/api unless is_api
         use-server graylog_1_rest if is_api
         use-server graylog_1 unless is_api
-        server graylog_1_rest 127.0.0.1:12900 maxconn 20 check
+        server graylog_1_rest 127.0.0.1:9000/api/ maxconn 20 check
         server graylog_1 127.0.0.1:9000 maxconn 20 check

--- a/pages/faq.rst
+++ b/pages/faq.rst
@@ -180,9 +180,9 @@ Send a POST request via the Graylog API Browser or curl to the ``/roles`` resour
     "read_only": false
    }
 
-The following curl command will create the required role (modify the URL of the Graylog REST API, here ``http://127.0.0.1:12900``, and the user credentials, here ``admin``/``admin``, according to your setup)::
+The following curl command will create the required role (modify the URL of the Graylog REST API, here ``http://127.0.0.1:9000/api/``, and the user credentials, here ``admin``/``admin``, according to your setup)::
   
-  $ curl -u admin:admin -H "Content-Type: application/json" -X POST -d '{"name": "Metrics Access", "description": "Provides read access to all system metrics", "permissions": ["metrics:*"], "read_only": false}' 'http://127.0.0.1:12900/roles'
+  $ curl -u admin:admin -H "Content-Type: application/json" -X POST -d '{"name": "Metrics Access", "description": "Provides read access to all system metrics", "permissions": ["metrics:*"], "read_only": false}' 'http://127.0.0.1:9000/api/roles'
 
 
 Troubleshooting

--- a/pages/index_model.rst
+++ b/pages/index_model.rst
@@ -66,7 +66,7 @@ This may take a few seconds but is an easy task for Graylog.
 
 You can easily re-build the information yourself after manually deleting indices or doing other changes that might cause synchronisation problems::
 
-  $ curl -XPOST http://127.0.0.1:12900/system/indices/ranges/rebuild
+  $ curl -XPOST http://127.0.0.1:9000/api/system/indices/ranges/rebuild
 
 This will trigger a systemjob::
 
@@ -85,7 +85,7 @@ Manually cycling the deflector
 Sometimes you might want to cycle the deflector manually and not wait until the configured rotation criterion for in the latest index has been reached.
 You can do this either via an HTTP request against the REST API of the Graylog master node or via the web interface::
 
-  $ curl -XPOST http://127.0.0.1:12900/system/deflector/cycle
+  $ curl -XPOST http://127.0.0.1:9000/api/system/deflector/cycle
 
 .. image:: /images/recalculate_index_ranges_2016.png
 

--- a/pages/installation/aws.rst
+++ b/pages/installation/aws.rst
@@ -15,7 +15,7 @@ Usage
   * Finish the wizard and spin up the VM.
   * Login to the instance as user `ubuntu`.
   * Run `sudo graylog-ctl reconfigure`.
-  * Open port 80 and 12900 in the applied security group to access the web interface.
+  * Open port 80 and 9000 in the applied security group to access the web interface.
   * additionally open more ports for ingesting log data, like 514 for syslog or 12201 for the GELF protocol.
 
 Open `http://<private ip>` in your browser to access the Graylog web interface. Default username and password is `admin`.
@@ -24,12 +24,12 @@ Networking
 ----------
 
 Your browser needs access to port 80 or 443 for reaching the web interface. The interface itself creates a connection
-back to the REST API of the Graylog server on port 12900. As long as you are in a private network like Amazon VPC for
+back to the REST API of the Graylog server on port 9000. As long as you are in a private network like Amazon VPC for
 instance, this works out of the box.
 If you want to use the *public* IP address of your VM, this mechanism doesn't work automatically anymore. You have
 to tell Graylog how to reach the API from the users browser perspective::
 
-  sudo graylog-ctl set-external-ip http://<public ip>:12900
+  sudo graylog-ctl set-external-ip http://<public ip>:9000/api/
   sudo graylog-ctl reconfigure
 
 Also make sure that this port is open, even on the public IP.

--- a/pages/installation/manual_setup.rst
+++ b/pages/installation/manual_setup.rst
@@ -177,7 +177,7 @@ There are a number of CLI parameters you can pass to the call in your ``graylogc
 Problems with IPv6 vs. IPv4?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If your `graylog-server` instance refuses to listen on IPv4 addresses and always chooses for example a `rest_listen_address` like `:::12900`
+If your `graylog-server` instance refuses to listen on IPv4 addresses and always chooses for example a `rest_listen_address` like `:::9000`
 you can tell the JVM to prefer the IPv4 stack.
 
 Add the `java.net.preferIPv4Stack` flag in your `graylogctl` script or from wherever you are calling the `graylog.jar`::

--- a/pages/installation/os/centos.rst
+++ b/pages/installation/os/centos.rst
@@ -97,8 +97,7 @@ If you're using SELinux on your system, you need to take care of the following s
 
 - Allow the web server to access the network: ``sudo setsebool -P httpd_can_network_connect 1``
 - If the policy above does not comply with your security policy, you can also allow access to each port individually:
-    - Graylog REST API: ``sudo semanage port -a -t http_port_t -p tcp 12900``
-    - Graylog web interface: ``sudo semanage port -a -t http_port_t -p tcp 9000``
+    - Graylog REST API and web interface: ``sudo semanage port -a -t http_port_t -p tcp 9000``
     - Elasticsearch (only if the HTTP API is being used): ``sudo semanage port -a -t http_port_t -p tcp 9200``
 - Allow using MongoDB's default port (27017/tcp): ``sudo semanage port -a -t mongod_port_t -p tcp 27017``
 

--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -230,7 +230,7 @@ Getting up and running with a web development environment is as easy as this::
 
 This clones the meta project repository, bootstraps the required modules and starts the web server. It even tries to open a browser window going to it (probably working on Mac OS X only).
 
-If your Graylog server is not running on ``http://localhost:12900``, then you need to edit ``graylog2-server/graylog2-web-interface/config.js`` (in your ``graylog-project`` directory) and adapt the ``gl2ServerUrl`` parameter.
+If your Graylog server is not running on ``http://localhost:9000/api/``, then you need to edit ``graylog2-server/graylog2-web-interface/config.js`` (in your ``graylog-project`` directory) and adapt the ``gl2ServerUrl`` parameter.
 
 Web Plugin structure
 --------------------

--- a/pages/users_and_roles/system_users.rst
+++ b/pages/users_and_roles/system_users.rst
@@ -30,7 +30,7 @@ Creating the role
 
 You can create a new role using the REST API like this::
 
-  curl -v -XPOST -H 'Content-Type: application/json' 'http://ADMIN:PASSWORD@graylog.example.org:12900/roles' -d '{"read_only": false,"permissions": ["processing:changestate"],"name": "Change processing state","description": "Permission to start or stop processing on graylog-server nodes"}'
+  curl -v -XPOST -H 'Content-Type: application/json' 'http://ADMIN:PASSWORD@graylog.example.org:9000/api/roles' -d '{"read_only": false,"permissions": ["processing:changestate"],"name": "Change processing state","description": "Permission to start or stop processing on graylog-server nodes"}'
 
 Notice the ``processing:changestate`` permission that we assigned. Every user with this role will be able to
 execute only calls that start or stop processing on ``graylog-server`` nodes. (and also the standard ``reader`` permissions
@@ -59,7 +59,7 @@ or maintenance functionalities.
 
 Now request the user information to see what permissions have been assigned::
 
-  $ curl -XGET 'http://ADMIN:PASSWORT@graylog.example.org:12900/users/maintenanceuser?pretty=true'
+  $ curl -XGET 'http://ADMIN:PASSWORT@graylog.example.org:9000/api/users/maintenanceuser?pretty=true'
   {
     "id" : "563d1024d4c63709999c4ac2",
     "username" : "maintenanceuser",


### PR DESCRIPTION
The Graylog REST API moved from http://127.0.0.1:12900/ to http://127.0.0.1:9000/api/

In a follow-up PR, we have to re-evaluate the proxy examples (nginx and Apache httpd) because those expect the Graylog REST API and the web interface to run on different ports. Most of them can be simplified for Graylog 2.1.x.
