### PR TITLE
Remove mentions of database abstraction layer for MongoDB

### DIFF
--- a/pages/architecture.rst
+++ b/pages/architecture.rst
@@ -13,8 +13,7 @@ There are a few rules of thumb when scaling resources for Graylog:
 Also keep in mind that messages are **only** stored in Elasticsearch. If you have data loss on
 Elasticsearch, the messages are gone - except if you have created backups of the indices.
 
-MongoDB is only storing meta information and will be abstracted with a general database layer
-in future versions. This will allow you to use other databases like MySQL instead.
+MongoDB is only storing meta information and configuration data.
 
 Minimum setup
 -------------

--- a/pages/faq.rst
+++ b/pages/faq.rst
@@ -25,8 +25,6 @@ What is MongoDB used for?
 
 Graylog uses MongoDB to store your configuration data, not your log data. Only metadata is stored, such as user information or stream configurations. None of your log messages are ever stored in MongoDB. This is why MongoDB does not have a big system impact, and you won’t have to worry too much about scaling it. With our recommended setup architecture, MongoDB will simply run alongside your graylog-server processes and use almost no resources.
 
-We have plans to introduce a database abstraction layer in the future. This will give you the flexibility to run MongoDB, MySQL or any other database to store metadata.
-
 Can you guide me on how to replicate MongoDB for High Availability?
 -------------------------------------------------------------------
 


### PR DESCRIPTION
We don't have concrete plans to do that in the short- or mid-term.
