### PR TITLE
Update manual installation instructions

### DIFF
--- a/pages/installation.rst
+++ b/pages/installation.rst
@@ -30,6 +30,8 @@ This chapter is explaining the many ways to install Graylog and aims to help cho
    installation/manual_setup
 
 
+.. _system-requirements:
+
 ===================
 System requirements
 ===================

--- a/pages/installation/manual_setup.rst
+++ b/pages/installation/manual_setup.rst
@@ -8,20 +8,8 @@ Graylog server on Linux
 Prerequisites
 ^^^^^^^^^^^^^
 
-You will need to have the following services installed on either the host you are running ``graylog-server`` on or on dedicated machines:
+Graylog depends on MongoDB and Elasticsearch to operate, please refer to :ref:`the system requirements <system-requirements>` for details.
 
-* `Elasticsearch 2.1.x or later <https://www.elastic.co/downloads/elasticsearch>`_
-* `MongoDB 2.0 or later <https://docs.mongodb.org/manual/administration/install-on-linux/>`_ (latest stable version is recommended)
-* Oracle Java SE 8 or later (Oracle Java SE 7 is end of life and is no longer supported. OpenJDK 8 also works; latest stable update is recommended)
-
-Most standard MongoDB packages of Linux distributions are outdated. Use the `official MongoDB APT repository <http://docs.mongodb.org/manual/tutorial/install-mongodb-on-debian/>`_
-(available for many distributions and operating systems)
-
-You also **must** install **Java 8** or higher! Java 7 is not compatible with Graylog and will also not receive any more publicly available bug and security
-fixes by Oracle.
-
-A more detailed guide for installing the dependencies will follow. **The only important thing for Elasticsearch is that you set
-the exactly same cluster name (e. g. ``cluster.name: graylog``) that is being used by Graylog in the Elasticsearch configuration (``conf/elasticsearch.yml``)**.
 
 Downloading and extracting the server
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,13 +40,7 @@ Configure at least the following variables in ``/etc/graylog/server/server.conf`
       ``password_secret`` for all of them!
  * ``root_password_sha2``
     * A SHA2 hash of a password you will use for your initial login. Set this to a SHA2 hash generated with ``echo -n yourpassword | shasum -a 256``
-      and you will be able to log in to the web interface with username *admin* and password *yourpassword*.
- * ``elasticsearch_max_docs_per_index = 20000000``
-    * How many log messages to keep per index. This setting multiplied with ``elasticsearch_max_number_of_indices`` results in the maximum number of
-      messages in your Graylog setup. It is always better to have several more smaller indices than just a few larger ones.
- * ``elasticsearch_max_number_of_indices = 20``
-    * How many indices to have in total. If this number is reached, the oldest index will be deleted. **Also take a look at the other retention
-      strategies that allow you to automatically delete messages based on their age.**
+      and you will be able to log in to the web interface with username **admin** and password **yourpassword**.
  * ``elasticsearch_shards = 4``
     * The number of shards for your indices. A good setting here highly depends on the number of nodes in your Elasticsearch cluster. If you have
       one node, set it to ``1``.
@@ -75,7 +57,6 @@ You need to have Java installed. Running the OpenJDK is totally fine and should 
 
   ~$ apt-get install openjdk-8-jre
 
-**You need at least Java 8** as Java 7 has reached EOL.
 
 Start the server::
 
@@ -88,13 +69,13 @@ example missing permissions.
 See the startup parameters description below to learn more about available startup parameters. Note that you might have to be `root`
 to bind to the popular port 514 for syslog inputs.
 
-You should see a line like this in the debug output of ``graylog-server`` successfully connected to your Elasticsearch cluster::
+You should see a line like this in the debug output of Graylog successfully connected to your Elasticsearch cluster::
 
   2013-10-01 12:13:22,382 DEBUG: org.elasticsearch.transport.netty - [graylog-server] connected to node [[Unuscione, Angelo][thN_gIBkQDm2ab7k-2Zaaw][inet[/10.37.160.227:9300]]]
 
-You can find the ``graylog-server`` logs in the directory ``logs/``.
+You can find the logs of Graylog in the directory ``logs/``.
 
-**Important:** All ``graylog-server`` instances must have synchronised time. We strongly recommend to use
+**Important:** All systems running Graylog must have synchronised system time. We strongly recommend to use
 `NTP <http://en.wikipedia.org/wiki/Network_Time_Protocol>`_ or similar mechanisms on all machines of your Graylog infrastructure.
 
 Supplying external logging configuration
@@ -167,27 +148,27 @@ Command line (CLI) parameters
 There are a number of CLI parameters you can pass to the call in your ``graylogctl`` script:
 
 * ``-h``, ``--help``: Show help message
-* ``-f CONFIGFILE``, ``--configfile CONFIGFILE``: Use configuration file `CONFIGFILE` for Graylog; default: ``/etc/graylog/server/server.conf``
+* ``-f CONFIGFILE``, ``--configfile CONFIGFILE``: Use configuration file ``CONFIGFILE`` for Graylog; default: ``/etc/graylog/server/server.conf``
 * ``-d``, ``--debug``: Run in debug mode
 * ``-l``, ``--local``: Run in local mode. Automatically invoked if in debug mode. Will not send system statistics, even if enabled and allowed. Only interesting for development and testing purposes.
-* ``-p PIDFILE``, ``--pidfile PIDFILE``: Set the file containing the PID of graylog to `PIDFILE`; default: `/tmp/graylog.pid`
-* ``-np``, ``--no-pid-file``: Do not write PID file (overrides `-p`/`--pidfile`)
+* ``-p PIDFILE``, ``--pidfile PIDFILE``: Set the file containing the PID of graylog to ``PIDFILE``; default: ``/tmp/graylog.pid``
+* ``-np``, ``--no-pid-file``: Do not write PID file (overrides ``-p``/``--pidfile``)
 * ``--version``: Show version of Graylog and exit
 
 Problems with IPv6 vs. IPv4?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If your `graylog-server` instance refuses to listen on IPv4 addresses and always chooses for example a `rest_listen_address` like `:::9000`
+If your Graylog node refuses to listen on IPv4 addresses and always chooses for example a ``rest_listen_address`` like ``:::9000``
 you can tell the JVM to prefer the IPv4 stack.
 
-Add the `java.net.preferIPv4Stack` flag in your `graylogctl` script or from wherever you are calling the `graylog.jar`::
+Add the ``java.net.preferIPv4Stack`` flag in your ``graylogctl`` script or from wherever you are calling the ``graylog.jar``::
 
     ~$ sudo -u graylog java -Djava.net.preferIPv4Stack=true -jar graylog.jar
 
 Create a message input and send a first message
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Log in to the web interface on port 9000 (e.g. ``http://127.0.0.1:9000``) and navigate to *System* -> *Nodes*. Select your ``graylog-server`` node there and click on *Manage inputs*.
+Log in to the web interface on port 9000 (e.g. ``http://127.0.0.1:9000``) and navigate to *System* -> *Nodes*. Select your Graylog node there and click on *Manage inputs*.
 
 .. image:: /images/create_input.png
 
@@ -203,19 +184,3 @@ see the message you just sent in. Click on it in the table and see it in detail:
 
 You have just sent your first message to Graylog! Why not spawn a syslog input and point some of your servers to it? You could also create some user
 accounts for your colleagues.
-
-HTTPS
-^^^^^
-
-Enabling HTTPS is easy. Just start the web interface TLS support in the ``/etc/graylog/server/server.conf`` like this::
-
-  web_enable_tls=true
-
-This will generate self-signed certificate. To use proper certificates you must provide a PEM-encoded private key in PKCS#8 format and a X.509 certificate.
-Most certificate authorities provide instructions on how to create such keys and certificates.
-
-The OpenSSL documentation also provides `examples on how to handle PKCS#8 files <https://www.openssl.org/docs/manmaster/apps/pkcs8.html#EXAMPLES>`_.
-
-* ``web_tls_cert_file`` The X.509 certificate file (PEM-encoded) to use for securing the web interface port.
-* ``web_tls_key_file`` The private key in PKCS#8 format (PEM-encoded) to use for securing the web interface port.
-* ``web_tls_key_password`` The password, defaults to a blank password


### PR DESCRIPTION
- Remove out-dated system requirements and link to the current ones
- Remove duplicate HTTPS instructions (they're explained in detail on another page)
- Fix markup
