### PR TITLE
Added deprecation notice for `transport_email_subject_prefix`.

### DIFF
--- a/pages/upgrade/graylog-2.2.rst
+++ b/pages/upgrade/graylog-2.2.rst
@@ -17,6 +17,8 @@ Due to the extensive rework done in alerting, this behavior has been modified to
 
 To simplify the transition for people relying on this behavior, we have added a migration step that will create an email alarm callback for each stream that has alert conditions, has alert receivers, but has no associated alarm callbacks.
 
+With to the introduction of email templates in 0.21, the ``transport_email_subject_prefix`` config setting became unused. It is now being removed completely. In early versions it was used to add a prefix to the generated subject of alerting emails. Since 0.21 it is possible to define a complete template used for the generation of alert email subjects.
+
 Default stream/Index Sets
 =========================
 


### PR DESCRIPTION
This setting has become unused and confuses users now.

Refs Graylog2/graylog2-server#3420, Graylog2/graylog2-server#3415,
Graylog2/graylog2-server#3419

Fixes #259