### PR TITLE
Restructure Plugin API documentation

### DIFF
--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -11,21 +11,23 @@ Graylog offers various extension points to customize and extend its functionalit
 The first step for writing a plugin is creating a skeleton that is the same for each type of plugin. The next chapter
 is explaining how to do this and will then go over to chapters explaining plugin types in detail.
 
+.. _plugin_types:
+
 Plugin Types
 ============
 
- Graylog comes with a stable plugin API for the following plugin types:
+Graylog comes with a stable plugin API for the following plugin types:
 
- * **Inputs:** Accept/write any messages into Graylog
- * **Outputs:** Forward messages to other endpoints in real-time
- * **Services:** Run at startup and able to implement any functionality
- * :ref:`alert_conditions`: Decide whether an alert will be triggered depending on a condition
- * :ref:`alert_notifications`: Called when a stream alert condition has been triggered
- * **Filters:** Transform/drop incoming messages during processing
- * **REST API Resources:** A REST resource to expose as part of the ``graylog-server`` REST API
- * **Periodical:** Called at periodical intervals during server runtime
- * :ref:`decorators`: Used during search time to modify the presentation of messages
- * **Authentication Realms:** Allowing to implement different authentication mechanisms (like single sign-on or 2FA)
+  * **Inputs:** Accept/write any messages into Graylog
+  * **Outputs:** Forward messages to other endpoints in real-time
+  * **Services:** Run at startup and able to implement any functionality
+  * :ref:`alert_conditions`: Decide whether an alert will be triggered depending on a condition
+  * :ref:`alert_notifications`: Called when a stream alert condition has been triggered
+  * **Filters:** Transform/drop incoming messages during processing
+  * **REST API Resources:** A REST resource to expose as part of the ``graylog-server`` REST API
+  * **Periodical:** Called at periodical intervals during server runtime
+  * :ref:`decorators`: Used during search time to modify the presentation of messages
+  * **Authentication Realms:** Allowing to implement different authentication mechanisms (like single sign-on or 2FA)
 
 .. toctree::
    :hidden:
@@ -46,6 +48,14 @@ What you need in your development environment before starting is:
 
 There are lots of different ways to get those on your local machine, unfortunately we cannot list all of them, so please refer to your operating system-specific documentation,
 
+.. _sample_plugin:
+
+Sample Plugin
+=============
+
+To go along with this documentation, there is a `sample plugin on Github <https://github.com/Graylog2/graylog-plugin-sample/tree/2.2>`_. Tis documentation will link to specific parts for your reference.
+It is fully functional, even though it does not implement any real logic. Its purpose so to give a reference for helping to implement your own plugins.
+
 .. _creating_plugin_skeleton:
 
 Creating a plugin skeleton
@@ -53,6 +63,8 @@ Creating a plugin skeleton
 
 The easiest way to get started is to use our `Graylog meta project <https://github.com/Graylog2/graylog-project>`_,
 which will create a complete plugin project infrastructure will all required classes, build definitions, and configurations. Using the meta project allows you to have the `Graylog server project <https://github.com/graylog2/graylog2-server>`_ and your own plugins (or 3rd party plugins) in the same project, which means that you can run and debug everything in your favorite IDE or navigate seamlessly in the code base.
+
+.. note:: We are working on a replacement tool for the ``graylog-project`` meta project, but for the time being it still works.
 
 Maven is a widely used build tool for Java, that comes pre-installed on many operating systems or can be installed using most package managers. Make sure that you have at least version 3 before you go on.
 
@@ -93,46 +105,64 @@ If you want to continue working on the command line, you can do the following to
   $ mvn package
 
 
-Change some default values
+The anatomy of a plugin
+=======================
+
+Each plugin contains information to describe itself and register the extensions it contains.
+
+.. note:: A single plugin can contain multiple extensions to Graylog.
+  
+  For example a hypothetical plugin might contribute an input, an output and alert notifications to communicate with systems. For convenience this would be bundled in a single plugin registering multiple extensions.
+
+Required classes
+----------------
+
+At the very minimum you need to implement two interfaces:
+
+  * ``org.graylog2.plugin.Plugin`` - which is the entry to your `plugin <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/java/org/graylog/plugins/sample/SamplePlugin.java>`_ code
+  * ``org.graylog2.plugin.PluginMetaData`` - which `describes your plugin <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/java/org/graylog/plugins/sample/SampleMetaData.java>`_
+
+The ``bootstrap-plugin`` script generates these implementations for you, and you simply need to fill out the details.
+
+Graylog uses Java's ServiceLoader mechanism to find your plugin's main class, so if you rename your ``Plugin`` implementation, you need to also adjust the `service file <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/resources/META-INF/services/org.graylog2.plugin.Plugin>`_.
+
+In addition to the service, Graylog needs an additional resource file called ``graylog-plugin.properties`` in a special location. This file contains information about the plugin, specifically which classloader the plugin needs to be in, so it needs to be read before the plugin is actually loaded.
+Typically you can simply take the default that has been `generated for you <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/resources/org.graylog.plugins.graylog-plugin-sample/graylog-plugin.properties>`_.
+
+Registering your extension
 --------------------------
 
-Open the ``JiraAlarmCallbackMetaData.java`` file and customize the default values like the plugin description, the website URI, and so on.
-Especially the author name etc. should be changed.
+So far the plugin itself does not do anything, because it neither implements any of the available extensions, nor could Graylog know which ones are available from your code.
 
-Now go on with implementing the actual login in one of the example plugin chapters below.
+Graylog uses `dependency injection <https://github.com/google/guice>`_ to wire up its internal components as well as the plugins. Thus the extensions a plugin provides need to be exposed as a ``PluginModule``.
+`It provides <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java>`_ you with a lot of helper methods to register the various available extensions to cut down the boiler plate code you have to write.
 
-Creating a plugin for the web interface
-=======================================
+An `empty module <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/java/org/graylog/plugins/sample/SampleModule.java>`_ is created for you.
 
+.. caution:: The ``PluginModule`` exposes a lot of extension points, but not all of them are considered stable API for external use.
+
+  If in doubt, please reach out to us on our `community support channels <https://www.graylog.org/community-support>`_.
+
+Please refer to the available :ref:`plugin_types` for detailed information what you can implement. The :ref:`sample_plugin` contains stub implementations for each of the supported extensions.
+
+Web Plugin creation
+-------------------
 Sometimes your plugin is not only supposed to work under the hoods inside a Graylog server as an input, output, alarm callback, etc. but you also want to contribute previously nonexisting functionality to Graylog's web interface. Since version 2.0 this is now possible. When using the most recent `Graylog meta project <https://github.com/Graylog2/graylog-project>`_ to bootstrap the plugin skeleton, you are already good to go for this. Otherwise please see our chapter about :ref:`creating_plugin_skeleton`.
 
 The Graylog web interface is written in JavaScript, based on `React <https://facebook.github.io/react/>`_. It is built using `webpack <http://webpack.github.io>`_, which is bundling all JavaScript code (and other files you use, like stylesheets, fonts, images, even audio or video files if you need them) into chunks digestable by your browser and npm_, which is managing our external (and own) dependencies. During the build process all of this will be bundled and included in the jar file of your plugin.
 
 This might be overwhelming at first if you are not accustomed to JS-development, but fortunately we have set up a lot to make writing plugins easier for you!
 
-Prerequisites
--------------
-
 If you use our proposed way for :ref:`creating_plugin_skeleton`, and followed the part about the :ref:`plugin_prerequisites`, you are already good to go for building a plugin with a web part. **All you need is a running Graylog server on your machine.** Everything else is fetched at build time!
-
-How to start development
-------------------------
 
 Getting up and running with a web development environment is as easy as this::
 
-  $ git clone https://github.com/Graylog2/graylog-project.git
-  [...]
-  $ cd graylog-project
-  $ scripts/bootstrap
-  [...]
-  $ scripts/bootstrap-plugin your-plugin
-  [...]
   $ scripts/start-web-dev
   [...]
   $ open http://localhost:8080
 
 
-This clones the meta project repository, bootstraps the required modules and starts the web server. It even tries to open a browser window going to it (probably working on Mac OS X only).
+This starts the development web server. It even tries to open a browser window going to it (probably working on Mac OS X only).
 
 If your Graylog server is not running on ``http://localhost:9000/api/``, then you need to edit ``graylog2-server/graylog2-web-interface/config.js`` (in your ``graylog-project`` directory) and adapt the ``gl2ServerUrl`` parameter.
 
@@ -152,6 +182,7 @@ These are the relevant files and directories in your plugin directory for the we
 
   src/web
     This is where the actual code for thw web part of your plugin goes to. For the start there is a simple ``index.jsx`` file, which shows you how to register your plugin and the parts it provides with the Graylog web interface. We will get to this in detail later.
+
 
 Required conventions for web plugins
 ====================================

--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -19,12 +19,13 @@ Plugin Types
 Graylog comes with a stable plugin API for the following plugin types:
 
   * **Inputs:** Accept/write any messages into Graylog
-  * **Outputs:** Forward messages to other endpoints in real-time
+  * **Outputs:** Forward ingested messages to other systems as they are processed
   * **Services:** Run at startup and able to implement any functionality
   * :ref:`alert_conditions_api`: Decide whether an alert will be triggered depending on a condition
   * :ref:`alert_notifications_api`: Called when a stream alert condition has been triggered
-  * **Filters:** Transform/drop incoming messages during processing
-  * **REST API Resources:** A REST resource to expose as part of the ``graylog-server`` REST API
+	* **Processors:** Transform/drop incoming messages (can create multiple new messages)
+  * **Filters:** Deprecated: Transform/drop incoming messages during processing
+  * **REST API Resources:** An HTTP resource exposed as part of the Graylog REST API
   * **Periodical:** Called at periodical intervals during server runtime
   * :ref:`decorators_api`: Used during search time to modify the presentation of messages
   * **Authentication Realms:** Allowing to implement different authentication mechanisms (like single sign-on or 2FA)

--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -21,17 +21,18 @@ Graylog comes with a stable plugin API for the following plugin types:
   * **Inputs:** Accept/write any messages into Graylog
   * **Outputs:** Forward messages to other endpoints in real-time
   * **Services:** Run at startup and able to implement any functionality
-  * :ref:`alert_conditions`: Decide whether an alert will be triggered depending on a condition
-  * :ref:`alert_notifications`: Called when a stream alert condition has been triggered
+  * :ref:`alert_conditions_api`: Decide whether an alert will be triggered depending on a condition
+  * :ref:`alert_notifications_api`: Called when a stream alert condition has been triggered
   * **Filters:** Transform/drop incoming messages during processing
   * **REST API Resources:** A REST resource to expose as part of the ``graylog-server`` REST API
   * **Periodical:** Called at periodical intervals during server runtime
-  * :ref:`decorators`: Used during search time to modify the presentation of messages
+  * :ref:`decorators_api`: Used during search time to modify the presentation of messages
   * **Authentication Realms:** Allowing to implement different authentication mechanisms (like single sign-on or 2FA)
 
 .. toctree::
    :hidden:
 
+   plugins/general_concepts
    plugins/alert_conditions
    plugins/alert_notifications
    plugins/decorators
@@ -47,6 +48,8 @@ What you need in your development environment before starting is:
   * `maven <https://maven.apache.org>`_
 
 There are lots of different ways to get those on your local machine, unfortunately we cannot list all of them, so please refer to your operating system-specific documentation,
+
+Graylog uses a couple of conventions and techniques in its code, so be sure to read about the :ref:`general_concepts_api` for an overview.
 
 .. _sample_plugin:
 

--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -23,12 +23,12 @@ Graylog comes with a stable plugin API for the following plugin types:
   * **Services:** Run at startup and able to implement any functionality
   * :ref:`alert_conditions_api`: Decide whether an alert will be triggered depending on a condition
   * :ref:`alert_notifications_api`: Called when a stream alert condition has been triggered
-	* **Processors:** Transform/drop incoming messages (can create multiple new messages)
-  * **Filters:** Deprecated: Transform/drop incoming messages during processing
+  * **Processors:** Transform/drop incoming messages (can create multiple new messages)
+  * **Filters:** (Deprecated) Transform/drop incoming messages during processing
   * **REST API Resources:** An HTTP resource exposed as part of the Graylog REST API
   * **Periodical:** Called at periodical intervals during server runtime
   * :ref:`decorators_api`: Used during search time to modify the presentation of messages
-  * **Authentication Realms:** Allowing to implement different authentication mechanisms (like single sign-on or 2FA)
+  * **Authentication Realms**: Allowing to implement different authentication mechanisms (like single sign-on or 2FA)
 
 .. toctree::
    :hidden:
@@ -128,7 +128,8 @@ At the very minimum you need to implement two interfaces:
 
 The ``bootstrap-plugin`` script generates these implementations for you, and you simply need to fill out the details.
 
-Graylog uses Java's ServiceLoader mechanism to find your plugin's main class, so if you rename your ``Plugin`` implementation, you need to also adjust the `service file <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/resources/META-INF/services/org.graylog2.plugin.Plugin>`_.
+Graylog uses Java's `ServiceLoader <https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html>`_ mechanism to find your plugin's main class, so if you rename your ``Plugin`` implementation, you need to also adjust the `service file <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/resources/META-INF/services/org.graylog2.plugin.Plugin>`_.
+Please also see Google Guava's `AutoService <https://github.com/google/auto/tree/master/service>`_ which Graylog uses in conjunction with the plain ServiceLoader.
 
 In addition to the service, Graylog needs an additional resource file called ``graylog-plugin.properties`` in a special location. This file contains information about the plugin, specifically which classloader the plugin needs to be in, so it needs to be read before the plugin is actually loaded.
 Typically you can simply take the default that has been `generated for you <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/resources/org.graylog.plugins.graylog-plugin-sample/graylog-plugin.properties>`_.
@@ -138,8 +139,7 @@ Registering your extension
 
 So far the plugin itself does not do anything, because it neither implements any of the available extensions, nor could Graylog know which ones are available from your code.
 
-Graylog uses `dependency injection <https://github.com/google/guice>`_ to wire up its internal components as well as the plugins. Thus the extensions a plugin provides need to be exposed as a ``PluginModule``.
-`It provides <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java>`_ you with a lot of helper methods to register the various available extensions to cut down the boiler plate code you have to write.
+Graylog uses `dependency injection <https://github.com/google/guice>`_ to wire up its internal components as well as the plugins. Thus the extensions a plugin provides need to be exposed as a `PluginModule <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/plugin/PluginModule.java>`_ which provides you with a lot of helper methods to register the various available extensions to cut down the boiler plate code you have to write.
 
 An `empty module <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/java/org/graylog/plugins/sample/SampleModule.java>`_ is created for you.
 

--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -57,8 +57,8 @@ Graylog uses a couple of conventions and techniques in its code, so be sure to r
 Sample Plugin
 -------------
 
-To go along with this documentation, there is a `sample plugin on Github <https://github.com/Graylog2/graylog-plugin-sample/tree/2.2>`_. Tis documentation will link to specific parts for your reference.
-It is fully functional, even though it does not implement any real logic. Its purpose so to give a reference for helping to implement your own plugins.
+To go along with this documentation, there is a `sample plugin on Github <https://github.com/Graylog2/graylog-plugin-sample/tree/2.2>`_. This documentation will link to specific parts for your reference.
+It is fully functional, even though it does not implement any useful functionality. Its purpose to provide a reference for helping to implement your own plugins.
 
 .. _creating_plugin_skeleton:
 

--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -4,8 +4,8 @@
 Plugins
 *******
 
-General information
-===================
+About Plugins
+=============
 Graylog offers various extension points to customize and extend its functionality through writing Java code.
 
 The first step for writing a plugin is creating a skeleton that is the same for each type of plugin. The next chapter
@@ -38,8 +38,8 @@ Graylog comes with a stable plugin API for the following plugin types:
 
 .. _plugin_prerequisites:
 
-Prerequisites
-=============
+Writing Plugins
+===============
 
 What you need in your development environment before starting is:
 
@@ -51,7 +51,7 @@ There are lots of different ways to get those on your local machine, unfortunate
 .. _sample_plugin:
 
 Sample Plugin
-=============
+-------------
 
 To go along with this documentation, there is a `sample plugin on Github <https://github.com/Graylog2/graylog-plugin-sample/tree/2.2>`_. Tis documentation will link to specific parts for your reference.
 It is fully functional, even though it does not implement any real logic. Its purpose so to give a reference for helping to implement your own plugins.
@@ -59,7 +59,7 @@ It is fully functional, even though it does not implement any real logic. Its pu
 .. _creating_plugin_skeleton:
 
 Creating a plugin skeleton
-==========================
+--------------------------
 
 The easiest way to get started is to use our `Graylog meta project <https://github.com/Graylog2/graylog-project>`_,
 which will create a complete plugin project infrastructure will all required classes, build definitions, and configurations. Using the meta project allows you to have the `Graylog server project <https://github.com/graylog2/graylog2-server>`_ and your own plugins (or 3rd party plugins) in the same project, which means that you can run and debug everything in your favorite IDE or navigate seamlessly in the code base.
@@ -106,7 +106,7 @@ If you want to continue working on the command line, you can do the following to
 
 
 The anatomy of a plugin
-=======================
+-----------------------
 
 Each plugin contains information to describe itself and register the extensions it contains.
 
@@ -115,7 +115,7 @@ Each plugin contains information to describe itself and register the extensions 
   For example a hypothetical plugin might contribute an input, an output and alert notifications to communicate with systems. For convenience this would be bundled in a single plugin registering multiple extensions.
 
 Required classes
-----------------
+................
 
 At the very minimum you need to implement two interfaces:
 
@@ -130,7 +130,7 @@ In addition to the service, Graylog needs an additional resource file called ``g
 Typically you can simply take the default that has been `generated for you <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/resources/org.graylog.plugins.graylog-plugin-sample/graylog-plugin.properties>`_.
 
 Registering your extension
---------------------------
+..........................
 
 So far the plugin itself does not do anything, because it neither implements any of the available extensions, nor could Graylog know which ones are available from your code.
 
@@ -146,7 +146,8 @@ An `empty module <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src
 Please refer to the available :ref:`plugin_types` for detailed information what you can implement. The :ref:`sample_plugin` contains stub implementations for each of the supported extensions.
 
 Web Plugin creation
--------------------
+...................
+
 Sometimes your plugin is not only supposed to work under the hoods inside a Graylog server as an input, output, alarm callback, etc. but you also want to contribute previously nonexisting functionality to Graylog's web interface. Since version 2.0 this is now possible. When using the most recent `Graylog meta project <https://github.com/Graylog2/graylog-project>`_ to bootstrap the plugin skeleton, you are already good to go for this. Otherwise please see our chapter about :ref:`creating_plugin_skeleton`.
 
 The Graylog web interface is written in JavaScript, based on `React <https://facebook.github.io/react/>`_. It is built using `webpack <http://webpack.github.io>`_, which is bundling all JavaScript code (and other files you use, like stylesheets, fonts, images, even audio or video files if you need them) into chunks digestable by your browser and npm_, which is managing our external (and own) dependencies. During the build process all of this will be bundled and included in the jar file of your plugin.
@@ -167,7 +168,7 @@ This starts the development web server. It even tries to open a browser window g
 If your Graylog server is not running on ``http://localhost:9000/api/``, then you need to edit ``graylog2-server/graylog2-web-interface/config.js`` (in your ``graylog-project`` directory) and adapt the ``gl2ServerUrl`` parameter.
 
 Web Plugin structure
---------------------
+....................
 
 These are the relevant files and directories in your plugin directory for the web part of it:
 
@@ -185,10 +186,10 @@ These are the relevant files and directories in your plugin directory for the we
 
 
 Required conventions for web plugins
-====================================
+------------------------------------
 
 Plugin Entrypoint
------------------
+.................
 
 There is a single file which is the entry point of your plugin, which means that the execution of your plugin starts there. By convention this is `src/web/index.jsx`. You can rename/move this file, you just have to adapt your webpack configuration to reflect this change, but it is not recommended.
 
@@ -200,22 +201,22 @@ In any case, this file needs to contain the following code at the very top::
 This part is responsible to include and execute the `webpack-entry <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-web-interface/src/webpack-entry.js>`_ file, which is responsible to set up webpack to use the correct URL format when loading assets for this plugin. If you leave this out, erratic behavior will be the result.
 
 Linking to other pages from your plugin
----------------------------------------
+.......................................
 
 If you want to generate links from the web frontend to other pages of your plugin or the main web interface, you need to use the ``Routes.pluginRoute()`` helper method to generate the URLs properly.
 
 See `this file <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-web-interface/src/routing/Routes.jsx#L5-L20>`_ for more information.
 
 Best practices for web plugin development
-=========================================
+-----------------------------------------
 
 Using ESLint
-------------
+............
 
 `ESLint <http://eslint.org>`_ is an awesome tool for linting JavaScript code. It makes sure that any written code is in line with general best practises and the project-specific coding style/guideline. We at Graylog are striving to make the best use of this tools as possible, to help our developers and you to generate top quality code with little bugs. Therefore we highly recommend to enable it for a Graylog plugin you are writing.
 
 Code Splitting
---------------
+..............
 
 Both the web interface and plugins for it depend on a number of libraries like React, RefluxJS and others. To prevent those getting bundled into *both* the web interface *and* plugin assets, therefore wasting space or causing problems (especially React does not like to be present more than once), we extract those into a commons chunk which is reused by the web interface and plugins.
 
@@ -224,7 +225,7 @@ This has no consequences for you as a plugin author, because the configuration t
 Common libraries are built into a separate ``vendor`` bundle using an own configuration file named `webpack.vendor.js <https://github.com/Graylog2/graylog2-server/blob/2.1/graylog2-web-interface/webpack.vendor.js>`_. Using the `DLLPlugin <https://github.com/webpack/docs/wiki/list-of-plugins>`_ a `manifest is extracted <https://github.com/Graylog2/graylog2-server/blob/2.1/graylog2-web-interface/webpack.vendor.js#L30-L33>`_ which allow us to reuse the generated bundle. This is then imported in our main `web interface webpack configuration file <https://github.com/Graylog2/graylog2-server/blob/2.1/graylog2-web-interface/webpack.config.js#L48>`_ and the corresponding `generated webpack config file for plugins <https://github.com/Graylog2/graylog-web-plugin/blob/master/src/PluginWebpackConfig.js#L45>`_.
 
 Building plugins
-================
+----------------
 
 Building the plugin is easy because the meta project has created all necessary files and settings for you. Just run ``mvn package`` either from the meta project's directory (to build the server *and* the plugin) or from the plugin
 directory (to build the plugin only)::

--- a/pages/plugins/alert_conditions.rst
+++ b/pages/plugins/alert_conditions.rst
@@ -22,7 +22,7 @@ Typically you will not implement ``AlertCondition`` directly, but instead use ``
 Example
 =======
 
-Please refer to the sample plugin implementation.
+Please refer to the sample `plugin implementation <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/java/org/graylog/plugins/sample/alerts/SampleAlertCondition.java>`_ for the full code.
 
 Bindings
 ========

--- a/pages/plugins/alert_conditions.rst
+++ b/pages/plugins/alert_conditions.rst
@@ -1,4 +1,4 @@
-.. _alert_conditions:
+.. _alert_conditions_api:
 
 ****************
 Alert Conditions

--- a/pages/plugins/alert_conditions.rst
+++ b/pages/plugins/alert_conditions.rst
@@ -6,7 +6,7 @@ Alert Conditions
 
 An alert condition determines whether an alert is triggered. The result of a condition is sent to an alert notification for sending to remote systems.
 
-In Graylog alerting is based on searches and typically includes a list of messages that lead to the alert. However nothing prevents user code to query other systems than elasticsearch to produce alerts.
+In Graylog alerting is based on searches and typically includes a list of messages that lead to the alert. However nothing prevents user code to query other systems than Elasticsearch to produce alerts.
 
 Class Overview
 ==============

--- a/pages/plugins/alert_conditions.rst
+++ b/pages/plugins/alert_conditions.rst
@@ -4,24 +4,49 @@
 Alert Conditions
 ****************
 
-General description of the plugin type goes here, should mention purpose of plugin and its relationship with other plugins or data structures if applicable.
+An alert condition determines whether an alert is triggered. The result of a condition is sent to an alert notification for sending to remote systems.
+
+In Graylog alerting is based on searches and typically includes a list of messages that lead to the alert. However nothing prevents user code to query other systems than elasticsearch to produce alerts.
 
 Class Overview
 ==============
 
-This section should list the relevant super classes or interfaces to implement.
+The central interface is ``org.graylog2.plugin.alarms.AlertCondition`` which is also the type that a plugin module must register using ``org.graylog2.plugin.PluginModule#addAlertCondition``.
+
+Alert conditions are configurable at runtime and thus need a corresponding ``org.graylog2.plugin.configuration.ConfigurationRequest``.
+
+Like many other types they also require a ``org.graylog2.plugin.alarms.AlertCondition.Descriptor`` for displaying information about the alert condition.
+
+Typically you will not implement ``AlertCondition`` directly, but instead use ``org.graylog2.alerts.AbstractAlertCondition`` which handles the configuration persistence for you automatically and implements two helper to provide the result of a condition check.
 
 Example
 =======
 
-A complete, but skeleton example should follow here.
+Please refer to the sample plugin implementation.
 
-Installation
-============
+Bindings
+========
 
-Binding examples should go here.
+Compare with the code in the `sample plugin <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/java/org/graylog/plugins/sample/SampleModule.java>`_.
+
+.. code:: java
+
+  public class SampleModule extends PluginModule {
+
+    @Override
+    public Set<? extends PluginConfigBean> getConfigBeans() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    protected void configure() {
+        addAlertCondition(SampleAlertCondition.class.getCanonicalName(),
+                SampleAlertCondition.class,
+                SampleAlertCondition.Factory.class);
+    }
+  }
 
 User Interface
 ==============
 
-If the plugin type requires special UI extensions to work, they should go here. Generic configuration must not be mentioned here.
+Alert conditions have no special user interface elements.

--- a/pages/plugins/alert_conditions.rst
+++ b/pages/plugins/alert_conditions.rst
@@ -1,0 +1,27 @@
+.. _alert_conditions:
+
+****************
+Alert Conditions
+****************
+
+General description of the plugin type goes here, should mention purpose of plugin and its relationship with other plugins or data structures if applicable.
+
+Class Overview
+==============
+
+This section should list the relevant super classes or interfaces to implement.
+
+Example
+=======
+
+A complete, but skeleton example should follow here.
+
+Installation
+============
+
+Binding examples should go here.
+
+User Interface
+==============
+
+If the plugin type requires special UI extensions to work, they should go here. Generic configuration must not be mentioned here.

--- a/pages/plugins/alert_notifications.rst
+++ b/pages/plugins/alert_notifications.rst
@@ -1,0 +1,76 @@
+.. _alert_notifications:
+
+*******************
+Alert Notifications
+*******************
+
+Alert Notifications are responsible for sending information about alerts to external systems, such as sending an email, push notifications, opening tickets, writing to chat systems etc.
+
+They receive the stream they were bound to as well as the result of the configured :ref:`alert_conditions`.
+
+.. note::
+  *Alert Notifications* were called *Alarm Callbacks* in previous versions of Graylog. 
+   The old name is still used in the code and REST API endpoints for backwards compatibility, so you will see it when implementing your plugins.
+
+Example Alarm Callback plugin
+=============================
+
+Let's assume you still want to build the mentioned JIRA AlarmCallback plugin. First open the ``JiraAlarmCallback.java`` file and let it implement
+the ``AlarmCallback`` interface::
+
+  public class JiraAlarmCallback implements AlarmCallback
+
+Your IDE should offer you to create the methods you need to implement:
+
+**public void initialize(Configuration configuration) throws AlarmCallbackConfigurationException**
+
+This is called once at the very beginning of the lifecycle of this plugin. It is common practive to store the ``Configuration`` as a private member
+for later access.
+
+**public void call(Stream stream, AlertCondition.CheckResult checkResult) throws AlarmCallbackException**
+
+This is the actual alarm callback being triggered. Implement your login that creates a JIRA ticket here.
+
+**public ConfigurationRequest getRequestedConfiguration()**
+
+Plugins can request configurations. The UI in the Graylog web interface is generated from this information and the filled out configuration values
+are passed back to the plugin in ``initialize(Configuration configuration)``.
+
+This is an example configuration request::
+
+  final ConfigurationRequest configurationRequest = new ConfigurationRequest();
+  configurationRequest.addField(new TextField(
+          "service_key", "Service key", "", "JIRA API token. You can find this token in your account settings.",
+          ConfigurationField.Optional.NOT_OPTIONAL)); // required, must be filled out
+  configurationRequest.addField(new BooleanField(
+          "use_https", "HTTPs", true,
+          "Use HTTP for API communication?"));
+
+**public String getName()**
+
+Return a human readable name of this plugin.
+
+**public Map<String, Object> getAttributes()**
+
+Return attributes that might be interesting to be shown under the alarm callback in the Graylog web interface. It is common practice to at least
+return the used configuration here.
+
+**public void checkConfiguration() throws ConfigurationException**
+
+Throw a ``ConfigurationException`` if the user should have entered missing or invalid configuration parameters.
+
+Registering the plugin
+----------------------
+
+.. _registering_alarm_callback:
+
+You now have to register your plugin in the ``JiraAlarmCallbackModule.java`` file to make ``graylog-server`` load the alarm callback when launching. The
+reason for the manual registering is that a plugin could consist of multiple plugin types. Think of the generated plugin file as a bundle of
+multiple plugins.
+
+Register your new plugin using the ``configure()`` method::
+
+  @Override
+  protected void configure() {
+      addAlarmCallback(JiraAlarmCallback.class);
+  }

--- a/pages/plugins/alert_notifications.rst
+++ b/pages/plugins/alert_notifications.rst
@@ -1,4 +1,4 @@
-.. _alert_notifications:
+.. _alert_notifications_api:
 
 *******************
 Alert Notifications

--- a/pages/plugins/alert_notifications.rst
+++ b/pages/plugins/alert_notifications.rst
@@ -6,7 +6,7 @@ Alert Notifications
 
 Alert Notifications are responsible for sending information about alerts to external systems, such as sending an email, push notifications, opening tickets, writing to chat systems etc.
 
-They receive the stream they were bound to as well as the result of the configured :ref:`alert_conditions`.
+They receive the stream they were bound to as well as the result of the configured :ref:`alert_conditions_api`.
 
 .. note:: Alert Notifications were called Alarm Callbacks in previous versions of Graylog. 
 

--- a/pages/plugins/decorators.rst
+++ b/pages/plugins/decorators.rst
@@ -1,8 +1,8 @@
 .. _decorators:
 
-****
+**********
 Decorators
-****
+**********
 
 Decorators can be used to transform a message field value during searches.
 

--- a/pages/plugins/decorators.rst
+++ b/pages/plugins/decorators.rst
@@ -40,6 +40,7 @@ Bindings
 Compare with the code in the `sample plugin <https://github.com/Graylog2/graylog-plugin-sample/blob/2.2/src/main/java/org/graylog/plugins/sample/SampleModule.java>`_.
 
 .. code:: java
+
   public class SampleModule extends PluginModule {
 
     @Override

--- a/pages/plugins/decorators.rst
+++ b/pages/plugins/decorators.rst
@@ -4,7 +4,7 @@
 Decorators
 **********
 
-:ref:`decorators` can be used to transform a message field value during searches. Multiple decorators can be applied at the same time, but you cannot make any assumptions about their order, as that is user defined.
+:ref:`decorators` can be used to transform a message field at display time. Multiple decorators can be applied at the same time, but you cannot make any assumptions about their order, as that is user defined. Stacked decorators receive the value of the previous decorator results.
 
 They are typically used to map between the stored value and a human readable form of that value,
 for example like the :ref:`syslog_severity_mapper` (compare its `code <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/decorators/SyslogSeverityMapperDecorator.java>`_) maps between numeric values and their textual respresentation.

--- a/pages/plugins/decorators.rst
+++ b/pages/plugins/decorators.rst
@@ -1,0 +1,58 @@
+.. _decorators:
+
+****
+Decorators
+****
+
+Decorators can be used to transform a message field value during searches.
+
+They are typically used to map between the stored value and a human readable form of that value,
+for example like the `Syslog severity mapper decorator <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/decorators/SyslogSeverityMapperDecorator.java>`_ maps between numeric values and their textual respresentation.
+
+Other uses include looking up user names based on a user's ID in a remote database, triggering a ``whois`` request on a domain name etc.
+
+.. _writing_decorators:
+
+Writing a decorator plugin
+==========================
+
+Writing a custom decorator is generally similar to the aforementioned alarm callback. After :ref:`creating_plugin_skeleton`, you need to implement a class implementing the ``SearchResponseDecorator`` interface. This class must:
+
+  * Contain interfaces extending the ``SearchResponseDecorator.Factory``, ``SearchResponseDecorator.Config`` & ``SearchResponseDecorator.Descriptor`` interface
+  * Implement a ``apply`` method, containing the actual logic of decorating a message
+
+The ``Factory`` interface needs a bit more explanation. It works as a connection between the factory, config, description and actual implementation classes. It should look similar to this::
+
+      public interface Factory extends SearchResponseDecorator.Factory {
+        @Override
+        YourMessageDecorator create(Decorator decorator);
+
+        @Override
+        YourMessageDecorator.Config getConfig();
+
+        @Override
+        YourMessageDecorator.Descriptor getDescriptor();
+      }
+
+In this example ``YourMessageDecorator`` is used as the base name for the class implementing a decorator.
+
+Registering the plugin
+----------------------
+
+Registering the decorator works generally similar to the alarm callback :ref:`example <registering_alarm_callback>`, the helper method used to register a decorator has a different name and signature though. In general it works like this::
+
+  @Override
+  protected void configure() {
+      installSearchResponseDecorator(searchResponseDecoratorBinder(),
+                                     YourMessageDecorator.class,
+                                     YourMessageDecorator.Factory.class);
+  }
+
+
+Writing the actual logic
+------------------------
+
+The actual logic of modifying the presentation of messages (or better: search results, as this is what a decorator is working on) is contained in the ``SearchResponseDecorator#apply`` method, which needs to be implemented.
+It is called every time a search is performed and this specific decorator is configured for the stream it is performed on. It receives a ``SearchResponse`` object and also needs to return one, but is able to manipulate it during the runtime of the ``apply`` call.
+
+A good example on how to write a decorator can be seen in the `source of the Syslog severity mapper decorator <https://github.com/Graylog2/graylog2-server/blob/master/graylog2-server/src/main/java/org/graylog2/decorators/SyslogSeverityMapperDecorator.java>`_.

--- a/pages/plugins/decorators.rst
+++ b/pages/plugins/decorators.rst
@@ -21,6 +21,7 @@ You need to implement the ``org.graylog2.plugin.decorators.SearchResponseDecorat
 Beyond the factory, configuration and descriptor classes, the only thing that a decorator needs to implement is the ``apply`` function:
 
 .. code:: java
+
 	SearchResponse apply(SearchResponse searchResponse);
 
 The ``org.graylog2.rest.resources.search.responses.SearchResponse`` class represents the result that is being returned to the web interface (or other callers of the REST API).

--- a/pages/plugins/general_concepts.rst
+++ b/pages/plugins/general_concepts.rst
@@ -1,0 +1,69 @@
+.. _general_concepts_api:
+
+API concepts
+************
+
+Graylog uses certain patterns in its code bases to make it easier to write extensions.
+It is important to know about these to be successful in writing custom for it.
+
+.. _concept_factory_api:
+
+Factory Class
+=============
+
+Many newer Graylog extension points split the common aspects of custom code into three different classes:
+
+* instance creation - an, usually inner, interface commonly called ``Factory``
+* configuration - the factory returns a ``ConfigurationRequest`` instance (or a wrapped instance of it), commonly called ``Config``
+* descriptor - the factory returns a display descriptor instance, commonly called ``Descriptor``
+
+Say Graylog exposes an extension point interface called ``ExtensionPoint``, which contains inner interfaces calles ``Factory``, ``Config`` and ``Descriptor``.
+An implementation of ``ExtensionPoint`` then looks as following:
+
+.. code:: java
+	public AwesomeExtension implements ExtensionPoint {
+		
+		public interface Factory extends ExtensionPoint.Factory {
+			@Override
+			AwesomeExtension create(Decorator decorator);
+
+			@Override
+			AwesomeExtension.Config getConfig();
+
+			@Override
+			AwesomeExtension.Descriptor getDescriptor();
+		}
+		
+		public static class Config implements ExtensionPoint.Config {
+			@Override
+			public ConfigurationRequest getRequestedConfiguration() {
+				return new ConfigurationRequest();
+			}
+		}
+
+		public static class Descriptor extends ExtensionPoint.Descriptor {
+			public Descriptor() {
+				super("awesome", "http://docs.graylog.org/", "Awesome Extension");
+			}
+		}
+	}
+
+This pattern is used to prevent instantiation of extensions just to get their descriptor or configuration information, because some extensions might be expensive to set up or require some external service and configuration to work.
+
+The factory itself is built using Guice's `assisted injection <https://github.com/google/guice/wiki/AssistedInject>`_ for auto-wired factories.
+This allows plugin authors (and Graylog's internals as well) to cleanly describe their extension as well as taking advantage of dependency injection.
+
+To register such an extension, Graylog typically offers a convenience method via its Guice modules (``GraylogModule`` or ``PluginModule``).
+For example alert conditions follow the same pattern and are registered as such:
+
+.. code:: java
+
+	public class SampleModule extends PluginModule {
+		// other methods omitted for clarity
+    @Override
+    protected void configure() {
+        addAlertCondition(SampleAlertCondition.class.getCanonicalName(),
+                SampleAlertCondition.class,
+                SampleAlertCondition.Factory.class);
+    }
+  }

--- a/pages/plugins/general_concepts.rst
+++ b/pages/plugins/general_concepts.rst
@@ -6,7 +6,7 @@ API concepts
 Graylog uses certain patterns in its code bases to make it easier to write extensions.
 It is important to know about these to be successful in writing custom for it.
 
-You can browse the ava
+You can browse the Graylog `Javadoc documentation <https://javadoc.io/doc/org.graylog2/graylog2-server/2.2.0>`_ for details on each class and method mentioned here.
 
 .. _concept_factory_api:
 

--- a/pages/plugins/general_concepts.rst
+++ b/pages/plugins/general_concepts.rst
@@ -6,6 +6,8 @@ API concepts
 Graylog uses certain patterns in its code bases to make it easier to write extensions.
 It is important to know about these to be successful in writing custom for it.
 
+You can browse the ava
+
 .. _concept_factory_api:
 
 Factory Class
@@ -61,10 +63,10 @@ For example alert conditions follow the same pattern and are registered as such:
 
 	public class SampleModule extends PluginModule {
 		// other methods omitted for clarity
-    @Override
-    protected void configure() {
-        addAlertCondition(SampleAlertCondition.class.getCanonicalName(),
-                SampleAlertCondition.class,
-                SampleAlertCondition.Factory.class);
-    }
-  }
+		@Override
+		protected void configure() {
+			addAlertCondition(SampleAlertCondition.class.getCanonicalName(),
+					SampleAlertCondition.class,
+					SampleAlertCondition.Factory.class);
+		}
+	}

--- a/pages/plugins/general_concepts.rst
+++ b/pages/plugins/general_concepts.rst
@@ -21,6 +21,7 @@ Say Graylog exposes an extension point interface called ``ExtensionPoint``, whic
 An implementation of ``ExtensionPoint`` then looks as following:
 
 .. code:: java
+
 	public AwesomeExtension implements ExtensionPoint {
 		
 		public interface Factory extends ExtensionPoint.Factory {

--- a/pages/queries.rst
+++ b/pages/queries.rst
@@ -221,6 +221,8 @@ screenshots:
 
 Field graphs appear every time you perform a search, allowing you to compare data, or combine graphs coming from different streams.
 
+.. _decorators:
+
 Decorators
 ==========
 Decorators allow you to alter message fields during search time automatically, while *preserving the unmodified message on disk*. Decorators
@@ -243,6 +245,8 @@ to apply from the dropdown, and click on *Apply*. Once you save your changes, th
 
 When you apply multiple decorators to the same search results, you can change the order in which they are applied at any time by using
 drag and drop in the decorator list.
+
+.. _syslog_severity_mapper:
 
 Syslog severity mapper
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The current plugin page is a bit difficult to follow if all you want is to get information about which kinds of plugins you can write and what specifics you need to implement one.

By splitting the documentation pages apart into a general section about how to bootstrap a plugin, the build process and other general guidelines and plugin point specific information we can make it easier for the community to extend Graylog.