### PR TITLE
Add description of pattern for parse_date() function

### DIFF
--- a/pages/pipelines/functions.rst
+++ b/pages/pipelines/functions.rst
@@ -579,6 +579,38 @@ parse_date
 Parses the ``value`` into a date and time object, using the ``pattern``. If no timezone is detected in the pattern, the optional
 timezone parameter is used as the assumed timezone. If omitted the timezone defaults to ``UTC``.
 
+The format used for the ``pattern`` parameter is identical to the pattern of the `Joda-Time DateTimeFormat <http://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html>`_.
+
+======  ===========================  ============  ==================================
+Symbol  Meaning                      Presentation  Examples
+======  ===========================  ============  ==================================
+``G``   era                          text          AD
+``C``   century of era (>=0)         number        20
+``Y``   year of era (>=0)            year          1996
+``x``   weekyear                     year          1996
+``w``   week of weekyear             number        27
+``e``   day of week                  number        2
+``E``   day of week                  text          Tuesday; Tue
+``y``   year                         year          1996
+``D``   day of year                  number        189
+``M``   month of year                month         July; Jul; 07
+``d``   day of month                 number        10
+``a``   halfday of day               text          PM
+``K``   hour of halfday (0~11)       number        0
+``h``   clockhour of halfday (1~12)  number        12
+``H``   hour of day (0~23)           number        0
+``k``   clockhour of day (1~24)      number        24
+``m``   minute of hour               number        30
+``s``   second of minute             number        55
+``S``   fraction of second           millis        978
+``z``   time zone                    text          Pacific Standard Time; PST
+``Z``   time zone offset/id          zone          -0800; -08:00; America/Los_Angeles
+``'``   escape for text              delimiter
+``''``  single quote                 literal       '
+======  ===========================  ============  ==================================
+
+
+
 flex_parse_date
 ---------------
 ``flex_parse_date(value: string, [default: DateTime], [timezone: string])``


### PR DESCRIPTION
The description of the `parse_date()` function lacks a formal description of the pattern string and doesn't even show examples, so that users are literally forced to read the source code or use trial and error.

This PR adds a hint to Joda-Time and adds a description of the pattern.