### PR TITLE
Add hint to `yum clean all` in RPM instructions

### DIFF
--- a/pages/installation/operating_system_packages.rst
+++ b/pages/installation/operating_system_packages.rst
@@ -124,8 +124,10 @@ If you've been using the repository package to install Graylog before, it has to
 The update basically works like a fresh installation::
 
   $ sudo rpm -Uvh https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.rpm
+  $ sudo yum clean all
   $ sudo yum install graylog-server
 
+Running ``yum clean all`` is required because YUM might use a stale cache and thus might be unable to find the latest version of the ``graylog-server`` package.
 
 Manual Repository Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Users have been irritated that YUM is in some cases unable to find the latest Graylog package, although the correct repository was being used.

As it turns out, YUM likes using a stale cache and needs a little kick in the cache with `yum clean all`.