### PR TITLE
updated Installation Section

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -10,7 +10,7 @@ You need a recent `docker` version `installed <https://docs.docker.com/installat
 This will create three containers with all Graylog services running::
 
   $ docker run --name some-mongo -d mongo:3
-  $ docker run --name some-elasticsearch -d elasticsearch:2 elasticsearch -Des.cluster.name="graylog"
+  $ docker run --name some-elasticsearch -d elasticsearch:5 elasticsearch -Des.cluster.name="graylog"
   $ docker run --link some-mongo:mongo --link some-elasticsearch:elasticsearch -p 9000:9000 -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" -d graylog2/server
 
 Testing a beta version
@@ -20,7 +20,7 @@ You can also run a pre-release (alpha, beta, or release candidate) version of Gr
 Follow this `guide <https://hub.docker.com/r/graylog2/server/>`_ and pick an alpha/beta/rc tag like::
 
   $ docker run --link some-mongo:mongo --link some-elasticsearch:elasticsearch -p 9000:9000 -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" -d graylog2/server:2.2.1-1
- 
+
 We only recommend running pre-release versions if you are an experienced Graylog user and know what you are doing.
 
 Settings
@@ -44,7 +44,7 @@ This all can be put in a `docker-compose.yml` file, like::
     mongo:
       image: "mongo:3"
     elasticsearch:
-      image: "elasticsearch:2"
+      image: "elasticsearch:5"
       command: "elasticsearch -Des.cluster.name='graylog'"
     graylog:
       image: graylog2/server:2.2.1-1
@@ -79,8 +79,8 @@ Create the configuration directory and copy the default files::
 
   mkdir /graylog/config
   cd /graylog/config
-  wget https://raw.githubusercontent.com/Graylog2/graylog2-images/2.2/docker/config/graylog.conf
-  wget https://raw.githubusercontent.com/Graylog2/graylog2-images/2.2/docker/config/log4j2.xml
+  wget https://raw.githubusercontent.com/Graylog2/graylog2-images/2.3/docker/config/graylog.conf
+  wget https://raw.githubusercontent.com/Graylog2/graylog2-images/2.3/docker/config/log4j2.xml
 
 The `docker-compose.yml` file looks like this::
 
@@ -91,7 +91,7 @@ The `docker-compose.yml` file looks like this::
       volumes:
         - /graylog/data/mongo:/data/db
     elasticsearch:
-      image: "elasticsearch:2"
+      image: "elasticsearch:5"
       command: "elasticsearch -Des.cluster.name='graylog'"
       volumes:
         - /graylog/data/elasticsearch:/usr/share/elasticsearch/data
@@ -115,7 +115,7 @@ The `docker-compose.yml` file looks like this::
 Start all services with exposed data directories::
 
   $ docker-compose up
- 
+
 Configuration
 -------------
 
@@ -156,7 +156,7 @@ In this example we created a new image with the Beats plugin installed. From now
       volumes:
         - /graylog/data/mongo:/data/db
     elasticsearch:
-      image: "elasticsearch:2"
+      image: "elasticsearch:5"
       command: "elasticsearch -Des.cluster.name='graylog'"
       volumes:
         - /graylog/data/elasticsearch:/usr/share/elasticsearch/data

--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -19,7 +19,7 @@ Testing a beta version
 You can also run a pre-release (alpha, beta, or release candidate) version of Graylog using Docker. The pre-releases are included in the `graylog2/server` image.
 Follow this `guide <https://hub.docker.com/r/graylog2/server/>`_ and pick an alpha/beta/rc tag like::
 
-  $ docker run --link some-mongo:mongo --link some-elasticsearch:elasticsearch -p 9000:9000 -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" -d graylog2/server:2.2.1-1
+  $ docker run --link some-mongo:mongo --link some-elasticsearch:elasticsearch -p 9000:9000 -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" -d graylog2/server:2.3.0-1
 
 We only recommend running pre-release versions if you are an experienced Graylog user and know what you are doing.
 
@@ -47,7 +47,7 @@ This all can be put in a `docker-compose.yml` file, like::
       image: "elasticsearch:5"
       command: "elasticsearch -Des.cluster.name='graylog'"
     graylog:
-      image: graylog2/server:2.2.1-1
+      image: graylog2/server:2.3.0-1
       environment:
         GRAYLOG_PASSWORD_SECRET: somepasswordpepper
         GRAYLOG_ROOT_PASSWORD_SHA2: 8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
@@ -96,7 +96,7 @@ The `docker-compose.yml` file looks like this::
       volumes:
         - /graylog/data/elasticsearch:/usr/share/elasticsearch/data
     graylog:
-      image: graylog2/server:2.2.1-1
+      image: graylog2/server:2.3.0-1
       volumes:
         - /graylog/data/journal:/usr/share/graylog/data/journal
         - /graylog/config:/usr/share/graylog/data/config
@@ -140,7 +140,7 @@ Plugins
 In order to add plugins you can build a new image based on the existing `graylog2/server` image with the needed plugin included. Simply
 create a new Dockerfile in an empty directory::
 
-  FROM graylog2/server:2.2.1-1
+  FROM graylog2/server:2.3.0-1
   RUN wget -O /usr/share/graylog/plugin/graylog-plugin-beats-1.1.0.jar https://github.com/Graylog2/graylog-plugin-beats/releases/download/1.1.0/graylog-plugin-beats-1.1.0.jar
 
 Build a new image from that::

--- a/pages/installation/openstack.rst
+++ b/pages/installation/openstack.rst
@@ -7,9 +7,9 @@ Installation
 
 Download the Graylog image from the `package <https://packages.graylog2.org/appliances/qcow2>`_ site, uncompress it and import it into the OpenStack image store::
 
-  $ wget https://packages.graylog2.org/releases/graylog-omnibus/qcow2/graylog-2.2.3-1.qcow2.gz
-  $ gunzip graylog-2.2.3-1.qcow2.gz
-  $ glance image-create --name='graylog' --is-public=true --container-format=bare --disk-format=qcow2 --file graylog-2.2.3-1.qcow2
+  $ wget https://packages.graylog2.org/releases/graylog-omnibus/qcow2/graylog-2.3.0-1.qcow2.gz
+  $ gunzip graylog-2.3.0-1.qcow2.gz
+  $ glance image-create --name='graylog' --is-public=true --container-format=bare --disk-format=qcow2 --file graylog-2.3.0-1.qcow2
 
 You should now see an image called `graylog` in the OpenStack web interface under `Images`
 

--- a/pages/installation/operating_system_packages.rst
+++ b/pages/installation/operating_system_packages.rst
@@ -23,7 +23,7 @@ Make sure to install and configure the following software before installing and 
 
 * Java (>= 8)
 * MongoDB (>= 2.4)
-* Elasticsearch (>= 5)
+* Elasticsearch (>= 2.x)
 
 .. caution:: Graylog 2.3 **does not** work with Elasticsearch 6.x!
 

--- a/pages/installation/operating_system_packages.rst
+++ b/pages/installation/operating_system_packages.rst
@@ -23,21 +23,21 @@ Make sure to install and configure the following software before installing and 
 
 * Java (>= 8)
 * MongoDB (>= 2.4)
-* Elasticsearch (>= 2.x)
+* Elasticsearch (>= 5)
 
-.. caution:: Graylog 2.x **does not** work with Elasticsearch 5.x!
+.. caution:: Graylog 2.3 **does not** work with Elasticsearch 6.x!
 
 .. _operating_package_DEB-APT:
 
 DEB / APT
 ---------
 
-Download and install `graylog-2.2-repository_latest.deb <https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.deb>`_
+Download and install `graylog-2.3-repository_latest.deb <https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb>`_
 via ``dpkg(1)`` and also make sure that the ``apt-transport-https`` package is installed::
 
   $ sudo apt-get install apt-transport-https
-  $ wget https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.deb
-  $ sudo dpkg -i graylog-2.2-repository_latest.deb
+  $ wget https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb
+  $ sudo dpkg -i graylog-2.3-repository_latest.deb
   $ sudo apt-get update
   $ sudo apt-get install graylog-server
 
@@ -68,8 +68,8 @@ If you've been using the repository package to install Graylog before, it has to
 
 The update basically works like a fresh installation::
 
-  $ wget https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.deb
-  $ sudo dpkg -i graylog-2.2-repository_latest.deb
+  $ wget https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb
+  $ sudo dpkg -i graylog-2.3-repository_latest.deb
   $ sudo apt-get update
   $ sudo apt-get install graylog-server
 
@@ -85,17 +85,17 @@ First, add the `Graylog GPG keyring <https://packages.graylog2.org/repo/debian/k
 
 Now create a file ``/etc/apt/sources.list.d/graylog.list`` with the following content::
 
-  deb https://packages.graylog2.org/repo/debian/ stable 2.2
+  deb https://packages.graylog2.org/repo/debian/ stable 2.3
 
 .. _operating_package_rpm-yum-dnf:
 
 RPM / YUM / DNF
 ---------------
 
-Download and install `graylog-2.2-repository_latest.rpm <https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.rpm>`_
+Download and install `graylog-2.3-repository_latest.rpm <https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.rpm>`_
 via ``rpm(8)``::
 
-  $ sudo rpm -Uvh https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.rpm
+  $ sudo rpm -Uvh https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.rpm
   $ sudo yum install graylog-server
 
 After the installation completed successfully, Graylog can be started with the following commands. Make sure to use the correct command for your operating system.
@@ -123,7 +123,7 @@ If you've been using the repository package to install Graylog before, it has to
 
 The update basically works like a fresh installation::
 
-  $ sudo rpm -Uvh https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.rpm
+  $ sudo rpm -Uvh https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.rpm
   $ sudo yum clean all
   $ sudo yum install graylog-server
 
@@ -142,7 +142,7 @@ Now create a file named ``/etc/yum.repos.d/graylog.repo`` with the following con
 
   [graylog]
   name=graylog
-  baseurl=https://packages.graylog2.org/repo/el/stable/2.2/$basearch/
+  baseurl=https://packages.graylog2.org/repo/el/stable/2.3/$basearch/
   gpgcheck=1
   gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog
 

--- a/pages/installation/os/centos.rst
+++ b/pages/installation/os/centos.rst
@@ -42,29 +42,31 @@ Additionally, run these last steps to start MongoDB during the operating system'
 Elasticsearch
 -------------
 
-Graylog 2.0.0 and higher requires Elasticsearch 2.x, so we took the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-repositories.html#_yum_dnf>`_.
+Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html>`_.
 
-First install the Elastic GPG key with ``rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch`` then add the repository file ``/etc/yum.repos.d/elasticsearch.repo`` with the following contents::
+First install the Elastic GPG key with ``rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch`` then add the repository file ``/etc/yum.repos.d/elasticsearch.repo`` with the following contents::
 
-  [elasticsearch-2.x]
-  name=Elasticsearch repository for 2.x packages
-  baseurl=https://packages.elastic.co/elasticsearch/2.x/centos
-  gpgcheck=1
-  gpgkey=https://packages.elastic.co/GPG-KEY-elasticsearch
-  enabled=1
+    [elasticsearch-5.x]
+    name=Elasticsearch repository for 5.x packages
+    baseurl=https://artifacts.elastic.co/packages/5.x/yum
+    gpgcheck=1
+    gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    enabled=1
+    autorefresh=1
+    type=rpm-md
 
 followed by the installation of the latest release with ``sudo yum install elasticsearch``.
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-configuration.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set `the cluster name <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-configuration.html#cluster-name>`__ to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/5.4/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
 
-  cluster.name: graylog
+    cluster.name: graylog
 
 After you have modified the configuration, you can start Elasticsearch::
 
-  $ sudo chkconfig --add elasticsearch
-  $ sudo systemctl daemon-reload
-  $ sudo systemctl enable elasticsearch.service
-  $ sudo systemctl restart elasticsearch.service
+    $ sudo chkconfig --add elasticsearch
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable elasticsearch.service
+    $ sudo systemctl restart elasticsearch.service
 
 
 Graylog
@@ -72,7 +74,7 @@ Graylog
 
 Now install the Graylog repository configuration and Graylog itself with the following commands::
 
-  $ sudo rpm -Uvh https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.rpm
+  $ sudo rpm -Uvh https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.rpm
   $ sudo yum install graylog-server
 
 Follow the instructions in your ``/etc/graylog/server/server.conf`` and add ``password_secret`` and ``root_password_sha2``. These settings are mandatory and without them, Graylog will not start!
@@ -128,7 +130,7 @@ Further reading
 Multiple Server Setup
 ---------------------
 
-If you plan to have multiple server taking care of different roles in your cluster :ref:`like we have in this big production setup <big_production_setup>` you need to modify only a few settings. This is covered in our :ref:`Multi-node Setup guide<configure_multinode>`. The :ref:`default file location guide <default_file_location>` will give you the file you need to modify in your setup. 
+If you plan to have multiple server taking care of different roles in your cluster :ref:`like we have in this big production setup <big_production_setup>` you need to modify only a few settings. This is covered in our :ref:`Multi-node Setup guide<configure_multinode>`. The :ref:`default file location guide <default_file_location>` will give you the file you need to modify in your setup.
 
 
 Feedback

--- a/pages/installation/os/centos.rst
+++ b/pages/installation/os/centos.rst
@@ -42,7 +42,7 @@ Additionally, run these last steps to start MongoDB during the operating system'
 Elasticsearch
 -------------
 
-Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/current/rpm.html>`_.
+Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/5.4/rpm.html>`_.
 
 First install the Elastic GPG key with ``rpm --import https://artifacts.elastic.co/GPG-KEY-elasticsearch`` then add the repository file ``/etc/yum.repos.d/elasticsearch.repo`` with the following contents::
 

--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -27,7 +27,7 @@ The version of MongoDB included in Debian Jessie is recent enough to be used wit
 Elasticsearch
 -------------
 
-Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html>`__::
+Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/5.4/deb.html>`__::
 
 
     $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -

--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -23,7 +23,7 @@ If you're starting from a minimal server setup, you will need to install these a
 MongoDB
 -------
 
-The version of MongoDB included in Debian Jessie is recent enough to be used with Graylog 2.0.0 and higher::
+The version of MongoDB included in Debian Jessie is recent enough to be used with Graylog 2.3.x and higher::
 
   $ sudo apt-get install mongodb-server
 
@@ -31,23 +31,23 @@ The version of MongoDB included in Debian Jessie is recent enough to be used wit
 Elasticsearch
 -------------
 
-Graylog 2.0.0 and higher requires Elasticsearch 2.x, so we took the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-repositories.html#_apt>`__::
+Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html>`__::
 
 
-  $ wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-  $ echo "deb https://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
-  $ sudo apt-get update && sudo apt-get install elasticsearch
+    $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+    $ echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
+    $ sudo apt-get update && sudo apt-get install elasticsearch
 
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-configuration.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set `the cluster name <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-configuration.html#cluster-name>`__ to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/5.4/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
 
-  cluster.name: graylog
+    cluster.name: graylog
 
 After you have modified the configuration, you can start Elasticsearch::
 
-  $ sudo systemctl daemon-reload
-  $ sudo systemctl enable elasticsearch.service
-  $ sudo systemctl restart elasticsearch.service
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable elasticsearch.service
+    $ sudo systemctl restart elasticsearch.service
 
 
 Graylog
@@ -55,8 +55,8 @@ Graylog
 
 Now install the Graylog repository configuration and Graylog itself with the following commands::
 
-  $ wget https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.deb
-  $ sudo dpkg -i graylog-2.2-repository_latest.deb
+  $ wget https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb
+  $ sudo dpkg -i graylog-2.3-repository_latest.deb
   $ sudo apt-get update && sudo apt-get install graylog-server
 
 Follow the instructions in your ``/etc/graylog/server/server.conf`` and add ``password_secret`` and ``root_password_sha2``. These settings are mandatory and without them, Graylog will not start!

--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -2,7 +2,7 @@
 Debian installation
 *******************
 
-This guide describes the fastest way to install Graylog on Debian Linux 8 (Jessie). All links and packages are present at the time of writing but might need to be updated later on.
+This guide describes the fastest way to install Graylog on Debian Linux 9 (Stretch). All links and packages are present at the time of writing but might need to be updated later on.
 
 .. warning:: This setup should not be done on publicly exposed servers. This guide **does not cover** security settings!
 
@@ -10,14 +10,10 @@ This guide describes the fastest way to install Graylog on Debian Linux 8 (Jessi
 Prerequisites
 -------------
 
-Not all required dependencies are available in the standard repository, so we need to add `Debian Backports <https://backports.debian.org>`__ to the list of package sources::
-
-  $ sudo echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/backports.list
-  $ sudo apt-get update && sudo apt-get upgrade
-
 If you're starting from a minimal server setup, you will need to install these additional packages::
 
-  $ sudo apt-get install apt-transport-https openjdk-8-jre-headless uuid-runtime pwgen
+  $ sudo apt update && sudo apt upgrade
+  $ sudo apt install apt-transport-https openjdk-8-jre-headless uuid-runtime pwgen
 
 
 MongoDB
@@ -25,7 +21,7 @@ MongoDB
 
 The version of MongoDB included in Debian Jessie is recent enough to be used with Graylog 2.3.x and higher::
 
-  $ sudo apt-get install mongodb-server
+  $ sudo apt install mongodb-server
 
 
 Elasticsearch
@@ -36,7 +32,7 @@ Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation
 
     $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
     $ echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
-    $ sudo apt-get update && sudo apt-get install elasticsearch
+    $ sudo apt update && sudo apt install elasticsearch
 
 
 Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/5.4/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
@@ -57,7 +53,7 @@ Now install the Graylog repository configuration and Graylog itself with the fol
 
   $ wget https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb
   $ sudo dpkg -i graylog-2.3-repository_latest.deb
-  $ sudo apt-get update && sudo apt-get install graylog-server
+  $ sudo apt update && sudo apt install graylog-server
 
 Follow the instructions in your ``/etc/graylog/server/server.conf`` and add ``password_secret`` and ``root_password_sha2``. These settings are mandatory and without them, Graylog will not start!
 

--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -12,8 +12,8 @@ Prerequisites
 
 Taking a minimal server setup as base will need this additional packages::
 
-  $ sudo apt-get update && sudo apt-get upgrade
-  $ sudo apt-get install apt-transport-https openjdk-8-jre-headless uuid-runtime pwgen
+    $ sudo apt-get update && sudo apt-get upgrade
+    $ sudo apt-get install apt-transport-https openjdk-8-jre-headless uuid-runtime pwgen
 
 
 MongoDB
@@ -21,13 +21,13 @@ MongoDB
 
 The Version included in Ubuntu 16.04 LTS can be used together with Graylog 2.3.x and higher::
 
-  $ sudo apt-get install mongodb-server
+    $ sudo apt-get install mongodb-server
 
 
 Elasticsearch
 -------------
 
-Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html>`__::
+Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/5.4/deb.html>`__::
 
 
     $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
@@ -50,15 +50,15 @@ Graylog
 
 Now install the Graylog repository configuration and Graylog itself with the following commands::
 
-  $ wget https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb
-  $ sudo dpkg -i graylog-2.3-repository_latest.deb
-  $ sudo apt-get update && sudo apt-get install graylog-server
+    $ wget https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb
+    $ sudo dpkg -i graylog-2.3-repository_latest.deb
+    $ sudo apt-get update && sudo apt-get install graylog-server
 
 Follow the instructions in your ``/etc/graylog/server/server.conf`` and add ``password_secret`` and ``root_password_sha2``. These settings are mandatory and without them, Graylog will not start!
 
 You need to use the following command to create your ``root_password_sha2``::
 
-  echo -n yourpassword | sha256sum
+    echo -n yourpassword | sha256sum
 
 To be able to connect to Graylog you should set ``rest_listen_uri`` and ``web_listen_uri`` to the public host name or a public IP address of the machine you can connect to. More information about these settings can be found in :ref:`Configuring the web interface <configuring_webif>`.
 
@@ -66,9 +66,9 @@ To be able to connect to Graylog you should set ``rest_listen_uri`` and ``web_li
 
 The last step is to enable Graylog during the operating system's startup::
 
-  $ sudo systemctl daemon-reload
-  $ sudo systemctl enable graylog-server.service
-  $ sudo systemctl start graylog-server.service
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable graylog-server.service
+    $ sudo systemctl start graylog-server.service
 
 The next step is to :ref:`ingest messages <ingest_data>` into your Graylog and extract the messages with :ref:`extractors <extractors>` or use :ref:`the Pipelines <pipelinestoc>` to work with the messages.
 

--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -19,7 +19,7 @@ Taking a minimal server setup as base will need this additional packages::
 MongoDB
 -------
 
-The Version included in Ubuntu 16.04 LTS can be used together with Graylog 2.0.0 and higher::
+The Version included in Ubuntu 16.04 LTS can be used together with Graylog 2.3.x and higher::
 
   $ sudo apt-get install mongodb-server
 
@@ -27,23 +27,22 @@ The Version included in Ubuntu 16.04 LTS can be used together with Graylog 2.0.0
 Elasticsearch
 -------------
 
-Graylog 2.0.0 and higher requires Elasticsearch 2.x, so we took the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-repositories.html#_apt>`__::
+Graylog 2.3.x can be used with Elasticsearch 5.x, please follow the installation instructions from `the Elasticsearch installation guide <https://www.elastic.co/guide/en/elasticsearch/reference/current/deb.html>`__::
 
 
-  $ wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-  $ echo "deb https://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elasticsearch-2.x.list
-  $ sudo apt-get update && sudo apt-get install elasticsearch
+    $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+    $ echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
+    $ sudo apt-get update && sudo apt-get install elasticsearch
 
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/5.4/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-configuration.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set `the cluster name <https://www.elastic.co/guide/en/elasticsearch/reference/2.3/setup-configuration.html#cluster-name>`__ to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
-
-  cluster.name: graylog
+    cluster.name: graylog
 
 After you have modified the configuration, you can start Elasticsearch::
 
-  $ sudo systemctl daemon-reload
-  $ sudo systemctl enable elasticsearch.service
-  $ sudo systemctl restart elasticsearch.service
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable elasticsearch.service
+    $ sudo systemctl restart elasticsearch.service
 
 
 Graylog
@@ -51,8 +50,8 @@ Graylog
 
 Now install the Graylog repository configuration and Graylog itself with the following commands::
 
-  $ wget https://packages.graylog2.org/repo/packages/graylog-2.2-repository_latest.deb
-  $ sudo dpkg -i graylog-2.2-repository_latest.deb
+  $ wget https://packages.graylog2.org/repo/packages/graylog-2.3-repository_latest.deb
+  $ sudo dpkg -i graylog-2.3-repository_latest.deb
   $ sudo apt-get update && sudo apt-get install graylog-server
 
 Follow the instructions in your ``/etc/graylog/server/server.conf`` and add ``password_secret`` and ``root_password_sha2``. These settings are mandatory and without them, Graylog will not start!

--- a/pages/installation/vagrant.rst
+++ b/pages/installation/vagrant.rst
@@ -11,7 +11,7 @@ Installation
 
 These steps will create a Vagrant virtual machine with all Graylog services running::
 
-  $ wget https://raw.githubusercontent.com/Graylog2/graylog2-images/2.2/vagrant/Vagrantfile
+  $ wget https://raw.githubusercontent.com/Graylog2/graylog2-images/2.3/vagrant/Vagrantfile
   $ vagrant up
 
 Usage


### PR DESCRIPTION
After we have Elasticsearch 5 the new "default" is elasticsearch 5 and updated links to 2.3 downloads/repos