### PR TITLE
Fix es5 configuration

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -10,7 +10,7 @@ You need a recent `docker` version `installed <https://docs.docker.com/installat
 This will create three containers with all Graylog services running::
 
   $ docker run --name some-mongo -d mongo:3
-  $ docker run --name some-elasticsearch -d elasticsearch:5 elasticsearch -Des.cluster.name="graylog"
+  $ docker run --name some-elasticsearch -d elasticsearch:5 elasticsearch -Ecluster.name="graylog"
   $ docker run --link some-mongo:mongo --link some-elasticsearch:elasticsearch -p 9000:9000 -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" -d graylog2/server
 
 Testing a beta version
@@ -45,7 +45,7 @@ This all can be put in a `docker-compose.yml` file, like::
       image: "mongo:3"
     elasticsearch:
       image: "elasticsearch:5"
-      command: "elasticsearch -Des.cluster.name='graylog'"
+      command: "elasticsearch -Ecluster.name='graylog'"
     graylog:
       image: graylog2/server:2.3.0-1
       environment:
@@ -92,7 +92,7 @@ The `docker-compose.yml` file looks like this::
         - /graylog/data/mongo:/data/db
     elasticsearch:
       image: "elasticsearch:5"
-      command: "elasticsearch -Des.cluster.name='graylog'"
+      command: "elasticsearch -Ecluster.name='graylog'"
       volumes:
         - /graylog/data/elasticsearch:/usr/share/elasticsearch/data
     graylog:
@@ -157,7 +157,7 @@ In this example we created a new image with the Beats plugin installed. From now
         - /graylog/data/mongo:/data/db
     elasticsearch:
       image: "elasticsearch:5"
-      command: "elasticsearch -Des.cluster.name='graylog'"
+      command: "elasticsearch -Ecluster.name='graylog'"
       volumes:
         - /graylog/data/elasticsearch:/usr/share/elasticsearch/data
     graylog:


### PR DESCRIPTION
The docker documentation [here](https://github.com/Graylog2/documentation/blob/2.3/pages/installation/docker.rst) says multiple times you need to run the elasticsearch 5 container with `command: "elasticsearch -Des.cluster.name='graylog'"`

As the -D option is [no longer](https://github.com/elastic/elasticsearch/issues/20652) in elasticsearch 5 you can't start the container which results in following log output.

```
      elasticsearch_1  | starts elasticsearch
      elasticsearch_1  |
      elasticsearch_1  | Option                Description
      elasticsearch_1  | ------                -----------
      elasticsearch_1  | -E <KeyValuePair>     Configure a setting
      elasticsearch_1  | -V, --version         Prints elasticsearch version information and exits
      elasticsearch_1  | -d, --daemonize       Starts Elasticsearch in the background
      elasticsearch_1  | -h, --help            show help
      elasticsearch_1  | -p, --pidfile <Path>  Creates a pid file in the specified path on start
      elasticsearch_1  | -q, --quiet           Turns off standard ouput/error streams logging in console
      elasticsearch_1  | -s, --silent          show minimal output
      elasticsearch_1  | -v, --verbose         show verbose output
      elasticsearch_1  | ERROR: D is not a recognized option
      graylog_elasticsearch_1 exited with code 64
```

You probably want to use `-Ecluster.name='graylog'` or a [configuration file](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/settings.html)