### PR TITLE
Fix for docker run elasticsearch

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -10,7 +10,7 @@ You need a recent `docker` version `installed <https://docs.docker.com/installat
 This will create three containers with all Graylog services running::
 
   $ docker run --name some-mongo -d mongo:3
-  $ docker run --name some-elasticsearch -d elasticsearch:5 elasticsearch -Des.cluster.name="graylog"
+  $ docker run --name some-elasticsearch -d elasticsearch:5 elasticsearch -Ecluster.name="graylog"
   $ docker run --link some-mongo:mongo --link some-elasticsearch:elasticsearch -p 9000:9000 -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" -d graylog2/server
 
 Testing a beta version


### PR DESCRIPTION
I tried the command with "-Des.cluster.name" and received an error that -D isn't a recognised option.

According to https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html, it should be "-Ecluster.name". I tested it and it worked.

"-Ees.cluster.name" also gives an error:
org.elasticsearch.bootstrap.StartupException: java.lang.IllegalArgumentException: unknown setting [es.cluster.name] did you mean [cluster.name]?