### PR TITLE
Clarify Java version requirements

### DIFF
--- a/pages/installation.rst
+++ b/pages/installation.rst
@@ -40,6 +40,6 @@ The Graylog server application has the following prerequisites:
 * Some modern Linux distribution (Debian Linux, Ubuntu Linux, or CentOS recommended)
 * `Elasticsearch 2.3.5 or later <https://www.elastic.co/downloads/elasticsearch>`_
 * `MongoDB 2.4 or later <https://docs.mongodb.org/manual/administration/install-on-linux/>`_ (latest stable version is recommended)
-* Oracle Java SE 8 or later (OpenJDK 8 also works; latest stable update is recommended)
+* Oracle Java SE 8 (OpenJDK 8 also works; latest stable update is recommended)
 
 .. caution:: Graylog prior to 2.3 **does not** work with Elasticsearch 5.x!


### PR DESCRIPTION
Graylog currently doesn't work with Java 9.

Refs Graylog2/graylog2-server#3885