### PR TITLE
added journal messages

### DIFF
--- a/pages/configuration/server.conf.rst
+++ b/pages/configuration/server.conf.rst
@@ -258,6 +258,7 @@ Rotation
 * ``index_ranges_cleanup_interval = 1h``
     * Time interval for index range information cleanups. This setting defines how often stale index range information is being purged from the database.
     * Default: 1h
+.. _output_batch_size:
 * ``output_batch_size = 500``
     * Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been reached within ``output_flush_interval`` seconds, everything that is available will be flushed at once. Remember that every output buffer processor manages its own batch and performs its own batch write calls. (``outputbuffer_processors`` variable)
 * ``output_flush_interval = 1``

--- a/pages/configuration/server.conf.rst
+++ b/pages/configuration/server.conf.rst
@@ -238,6 +238,8 @@ Rotation
 
 ================================
 
+.. _output_batch_size:
+
 * ``allow_leading_wildcard_searches = false``
     * Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only be enabled with care.
     * See also: :ref:`queries`
@@ -258,7 +260,6 @@ Rotation
 * ``index_ranges_cleanup_interval = 1h``
     * Time interval for index range information cleanups. This setting defines how often stale index range information is being purged from the database.
     * Default: 1h
-.. _output_batch_size:
 * ``output_batch_size = 500``
     * Batch size for the Elasticsearch output. This is the maximum (!) number of messages the Elasticsearch output module will get at once and write to Elasticsearch in a batch call. If the configured batch size has not been reached within ``output_flush_interval`` seconds, everything that is available will be flushed at once. Remember that every output buffer processor manages its own batch and performs its own batch write calls. (``outputbuffer_processors`` variable)
 * ``output_flush_interval = 1``

--- a/pages/faq.rst
+++ b/pages/faq.rst
@@ -155,6 +155,23 @@ To be able to use a privileged port, you can use `authbind <https://en.wikipedia
 The input needs to be started on port 1514 in this case and will be made available on port 514 to the outside. The clients can then send data to port 514.
 
 
+What does "Uncommited messages deleted from journal" means?
+-----------------------------------------------------------
+Some messages were deleted from the Graylog journal before they could be written to Elasticsearch. Please
+verify that your Elasticsearch cluster is healthy and fast enough. You may also want to review your Graylog
+journal settings and set a higher limit.
+
+Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
+
+
+What does "Journal utilization is too high" means?
+--------------------------------------------------
+Journal utilization is too high and may go over the limit soon. Please verify that your Elasticsearch cluster
+is healthy and fast enough. You may also want to review your Graylog journal settings and set a higher limit.
+
+Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
+
+
 Graylog & Integrations
 ======================
 

--- a/pages/faq.rst
+++ b/pages/faq.rst
@@ -248,21 +248,21 @@ The best option, apart from not sending fields with dots, is to remember to writ
 
 For example, if an incoming message contains the field ``docker.container`` stream rules use that name, whereas alert conditions need to use ``docker_container``. You will notice that the search results also use the latter name.
 
-What does "Uncommited messages deleted from journal" means?
+What does "Uncommited messages deleted from journal" mean?
 -----------------------------------------------------------
 Some messages were deleted from the Graylog journal before they could be written to Elasticsearch. Please
 verify that your Elasticsearch cluster is healthy and fast enough. You may also want to review your Graylog
 journal settings and set a higher limit.
 
-Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
+This can happen when Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
 
 
-What does "Journal utilization is too high" means?
+What does "Journal utilization is too high" mean?
 --------------------------------------------------
 Journal utilization is too high and may go over the limit soon. Please verify that your Elasticsearch cluster
 is healthy and fast enough. You may also want to review your Graylog journal settings and set a higher limit.
 
-Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
+This can happen when Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
 
 
 Have another troubleshooting question?

--- a/pages/faq.rst
+++ b/pages/faq.rst
@@ -155,23 +155,6 @@ To be able to use a privileged port, you can use `authbind <https://en.wikipedia
 The input needs to be started on port 1514 in this case and will be made available on port 514 to the outside. The clients can then send data to port 514.
 
 
-What does "Uncommited messages deleted from journal" means?
------------------------------------------------------------
-Some messages were deleted from the Graylog journal before they could be written to Elasticsearch. Please
-verify that your Elasticsearch cluster is healthy and fast enough. You may also want to review your Graylog
-journal settings and set a higher limit.
-
-Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
-
-
-What does "Journal utilization is too high" means?
---------------------------------------------------
-Journal utilization is too high and may go over the limit soon. Please verify that your Elasticsearch cluster
-is healthy and fast enough. You may also want to review your Graylog journal settings and set a higher limit.
-
-Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
-
-
 Graylog & Integrations
 ======================
 
@@ -264,6 +247,22 @@ Thus alert conditions need to use the ``_`` instead of ``.`` when referring to f
 The best option, apart from not sending fields with dots, is to remember to write alert conditions using the replacement character, and never use ``.`` in the field names. In general Graylog will use the version with ``_`` in searches etc.
 
 For example, if an incoming message contains the field ``docker.container`` stream rules use that name, whereas alert conditions need to use ``docker_container``. You will notice that the search results also use the latter name.
+
+What does "Uncommited messages deleted from journal" means?
+-----------------------------------------------------------
+Some messages were deleted from the Graylog journal before they could be written to Elasticsearch. Please
+verify that your Elasticsearch cluster is healthy and fast enough. You may also want to review your Graylog
+journal settings and set a higher limit.
+
+Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
+
+
+What does "Journal utilization is too high" means?
+--------------------------------------------------
+Journal utilization is too high and may go over the limit soon. Please verify that your Elasticsearch cluster
+is healthy and fast enough. You may also want to review your Graylog journal settings and set a higher limit.
+
+Most times Graylog is not able to connect to Elasticsearch or the Elasticsearch Cluster is not able to process the ingested messages in time. Add more resources to Elasticsearch or adjust :ref:`the output settings <output_batch_size>` from Graylog to Elasticsearch.
 
 
 Have another troubleshooting question?


### PR DESCRIPTION
After feedback from the community ( https://community.graylog.org/t/graylog-uncommited-messages-deleted-from-journal-utilization-is-too-high/3177/6 ) and some Enterprise Customers I added the error message to the FAQ and put some additional information to it.

This might be good become one chapter "troubleshooting" but currently its better to find that error in the documentation than noting. 

ppl do not read the online description of this error!