### PR TITLE
reworked enterprise install

### DIFF
--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -42,21 +42,59 @@ The following list shows the minimum required Graylog versions for the Graylog E
 Installation
 ============
 
-Once you `purchase a license for Graylog Enterprise <https://www.graylog.org/enterprise/>`_,
-you will get download links for the tarballs and DEB/RPM packages in the confirmation mail.
+Since Graylog 2.4 the Graylog Enterprise Plugins can be installed the same way Graylog is installed. In most setups this will be done with the package tool provided by the distribution you are using and the online repository.
 
-.. note:: The Graylog Enterprise plugins need to be installed on all your Graylog nodes!
+.. note:: For previous versions of Graylog Enterprise please contact your support representive.
+
+Once you installed the Graylog Enterprise Plugins you need to optain a License from `the Graylog Enterprise Page <https://www.graylog.org/enterprise/>`_. 
+
+Should a simple `apt-get install graylog-enterprise-plugins` or `yum install graylog-enterprise-plugins` not work for you, the following information might help you.
+
+.. important:: The Graylog Enterprise plugins need to be installed on all your Graylog nodes!
+
+DEB / RPM Package
+-----------------
+
+We also provide DEB and RPM packages for the enterprise plugins, that can be obtained from our repository to apply them to server that are not able to download them online.
+
+All packages are located at `https://packages.graylog2.org <https://packages.graylog2.org>`_  
+
+.. note:: These packages can **only** be used when you installed Graylog via the :doc:`/pages/installation/operating_system_packages`!
+
+DEB
+~~~
+
+Download the plugins `from the repository <https://packages.graylog2.org/debian/pool/stable/2.4/g/graylog-enterprise-plugins>`_ and transfer them to the server. Use the following command to install the plugins via dpkg.
+
+::
+
+  $ sudo dpkg -i graylog-enterprise-plugins_2.4.0-1_all.deb
+
+RPM
+~~~
+
+Download the plugins `from the repository <https://packages.graylog2.org/el/stable/2.4/x86_64>`_ and transfer them to the server. Use the following command to install the plugins via rpm.
+
+::
+
+  $ sudo rpm -Uvh graylog-enterprise-plugins-2.4.0-1.noarch.rpm
+
+
 
 Tarball
 -------
+
+If you have done a manual installation or want to include only parts of the enterprise plugins you can get the tarball from `the Graylog Enterprise Page <https://www.graylog.org/enterprise/>`_. 
 
 The tarball includes the enterprise plugin JAR files.
 
 ::
 
-  $ tar -tzf graylog-enterprise-plugins-1.0.0.tgz
-  graylog-enterprise-plugins-1.0.0/plugin/graylog-plugin-archive-1.0.0.jar
-  graylog-enterprise-plugins-1.0.0/plugin/graylog-plugin-license-1.0.0.jar
+  $ tar -tzf graylog-enterprise-plugins-2.4.0.tgz
+    graylog-enterprise-plugins-2.4.0/LICENSE
+    graylog-enterprise-plugins-2.4.0/plugin/graylog-plugin-archive-2.4.0.jar
+    graylog-enterprise-plugins-2.4.0/plugin/graylog-plugin-auditlog-2.4.0.jar
+    graylog-enterprise-plugins-2.4.0/plugin/graylog-plugin-license-2.4.0.jar
 
 Depending on the Graylog setup method you have used, you have to install the plugins into different locations.
 
@@ -70,39 +108,19 @@ Your plugin directory should look similar to this after installing the enterpris
 ::
 
   plugin/
-  ├── graylog-plugin-archive-1.0.0.jar
-  ├── graylog-plugin-collector-1.0.2.jar
-  ├── graylog-plugin-enterprise-integration-1.0.2.jar
-  ├── graylog-plugin-license-1.0.0.jar
-  ├── graylog-plugin-map-widget-1.0.2.jar
-  ├── graylog-plugin-pipeline-processor-1.0.0-beta.4.jar
-  └── usage-statistics-2.0.2.jar
-
-
-DEB / RPM Package
------------------
-
-We also provide DEB and RPM packages for the enterprise plugins.
-
-.. note:: These packages can **only** be used when you installed Graylog via the :doc:`/pages/installation/operating_system_packages`!
-
-DEB
-~~~
-
-Use the following command to install the plugins via dpkg.
-
-::
-
-  $ sudo dpkg -i graylog-enterprise-plugins-1.0.0.deb
-
-RPM
-~~~
-
-Use the following command to install the plugins via rpm.
-
-::
-
-  $ sudo rpm -Uvh graylog-enterprise-plugins-1.0.0-1.noarch.rpm
+  ├── graylog-plugin-auditlog-2.4.0.jar
+  ├── graylog-plugin-threatintel-2.4.0.jar
+  ├── graylog-plugin-archive-2.4.0.jar
+  ├── graylog-plugin-beats-2.4.0.jar
+  ├── graylog-plugin-netflow-2.4.0.jar
+  ├── graylog-plugin-aws-2.4.0.jar
+  ├── graylog-plugin-pipeline-processor-2.4.0.jar
+  ├── graylog-plugin-enterprise-integration-2.4.0.jar
+  ├── graylog-plugin-map-widget-2.4.0.jar
+  ├── graylog-plugin-cef-2.4.0.jar
+  ├── graylog-plugin-license-2.4.0.jar
+  └── graylog-plugin-collector-2.4.0.jar
+  
 
 
 Server Restart
@@ -117,8 +135,17 @@ You should see something like the following in your Graylog server logs. It indi
 
 ::
 
-  2016-05-30 12:06:34,606 INFO : org.graylog2.bootstrap.CmdLineTool - Loaded plugin: ArchivePlugin 1.0.0 [org.graylog.plugins.archive.ArchivePlugin]
-  2016-05-30 12:06:34,607 INFO : org.graylog2.bootstrap.CmdLineTool - Loaded plugin: License Plugin 1.0.0 [org.graylog.plugins.license.LicensePlugin]
+  2017-12-18T17:39:10.797+01:00 INFO  [CmdLineTool] Loaded plugin: AWS plugins 2.4.0 [org.graylog.aws.plugin.AWSPlugin]
+  2017-12-18T17:39:10.803+01:00 INFO  [CmdLineTool] Loaded plugin: Audit Log 2.4.0 [org.graylog.plugins.auditlog.AuditLogPlugin]
+  2017-12-18T17:39:10.805+01:00 INFO  [CmdLineTool] Loaded plugin: Elastic Beats Input 2.4.0 [org.graylog.plugins.beats.BeatsInputPlugin]
+  2017-12-18T17:39:10.807+01:00 INFO  [CmdLineTool] Loaded plugin: CEF Input 2.4.0 [org.graylog.plugins.cef.CEFInputPlugin]
+  2017-12-18T17:39:10.809+01:00 INFO  [CmdLineTool] Loaded plugin: Collector 2.4.0 [org.graylog.plugins.collector.CollectorPlugin]
+  2017-12-18T17:39:10.811+01:00 INFO  [CmdLineTool] Loaded plugin: Enterprise Integration Plugin 2.4.0 [org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin]
+  2017-12-18T17:39:10.812+01:00 INFO  [CmdLineTool] Loaded plugin: License Plugin 2.4.0 [org.graylog.plugins.license.LicensePlugin]
+  2017-12-18T17:39:10.814+01:00 INFO  [CmdLineTool] Loaded plugin: MapWidgetPlugin 2.4.0 [org.graylog.plugins.map.MapWidgetPlugin]
+  2017-12-18T17:39:10.815+01:00 INFO  [CmdLineTool] Loaded plugin: NetFlow Plugin 2.4.0 [org.graylog.plugins.netflow.NetFlowPlugin]
+  2017-12-18T17:39:10.826+01:00 INFO  [CmdLineTool] Loaded plugin: Pipeline Processor Plugin 2.4.0 [org.graylog.plugins.pipelineprocessor.ProcessorPlugin]
+  2017-12-18T17:39:10.827+01:00 INFO  [CmdLineTool] Loaded plugin: Threat Intelligence Plugin 2.4.0 [org.graylog.plugins.threatintel.ThreatIntelPlugin]
 
 Cluster Setup
 =============
@@ -131,7 +158,7 @@ License Installation
 
 The Graylog Enterprise plugins require a valid license to use the additional features.
 
-Once you have `purchased a license <https://www.graylog.org/enterprise/>`_
+Once you have `optained a license <https://www.graylog.org/enterprise/>`_
 you can import it into your Graylog setup by going through the following steps.
 
 #. As an admin user, open the System/License page from the menu in the web interface.

--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -42,11 +42,11 @@ The following list shows the minimum required Graylog versions for the Graylog E
 Installation
 ============
 
-Since Graylog 2.4 the Graylog Enterprise Plugins can be installed the same way Graylog is installed. In most setups this will be done with the package tool provided by the distribution you are using and the online repository.
+Since Graylog 2.4 the Graylog Enterprise plugins can be installed the same way Graylog is installed. In most setups this will be done with the package tool provided by the distribution you are using and the online repository.
 
-.. note:: For previous versions of Graylog Enterprise please contact your support representive.
+.. note:: For previous versions of Graylog Enterprise please contact your Graylog account manager.
 
-Once you installed the Graylog Enterprise Plugins you need to optain a License from `the Graylog Enterprise Page <https://www.graylog.org/enterprise/>`_. 
+Once you installed the Graylog Enterprise plugins you need to obtain a license from `the Graylog Enterprise web page <https://www.graylog.org/enterprise/>`_. 
 
 Should a simple `apt-get install graylog-enterprise-plugins` or `yum install graylog-enterprise-plugins` not work for you, the following information might help you.
 
@@ -55,36 +55,36 @@ Should a simple `apt-get install graylog-enterprise-plugins` or `yum install gra
 DEB / RPM Package
 -----------------
 
-We also provide DEB and RPM packages for the enterprise plugins, that can be obtained from our repository to apply them to server that are not able to download them online.
+The default installation should be done with the system package tools. It includes the repository installation that is described in the :doc:`/pages/installation/operating_system_packages` installation guides. 
 
-All packages are located at `https://packages.graylog2.org <https://packages.graylog2.org>`_  
+When the usage of online repositorys is not possible in your environment, you can download the Graylog Enterprise plugins at `https://packages.graylog2.org <https://packages.graylog2.org>`_. 
 
 .. note:: These packages can **only** be used when you installed Graylog via the :doc:`/pages/installation/operating_system_packages`!
 
 DEB
 ~~~
 
-Download the plugins `from the deb repository <https://packages.graylog2.org/debian/pool/stable/2.4/g/graylog-enterprise-plugins>`_ and transfer them to the server. Use the following command to install the plugins via dpkg.
+The installation on distributions like Debian or Ubuntu could be done with *apt-get* as installation tool from the previous installed online repository.  
 
 ::
+  
+  $ sudo apt-get install graylog-enterprise-plugins
 
-  $ sudo dpkg -i graylog-enterprise-plugins_2.4.0-1_all.deb
 
 RPM
 ~~~
 
-Download the plugins `from the rpm repository <https://packages.graylog2.org/el/stable/2.4/x86_64>`_ and transfer them to the server. Use the following command to install the plugins via rpm.
+The installation on distributions like CentOS or RedHat could be done with *yum* as installation tool from the previous installed online repository.
 
 ::
-
-  $ sudo rpm -Uvh graylog-enterprise-plugins-2.4.0-1.noarch.rpm
-
+  
+  $ sudo yum install graylog-enterprise-plugins
 
 
 Tarball
 -------
 
-If you have done a manual installation or want to include only parts of the enterprise plugins you can get the tarball from `the Graylog Enterprise Page <https://www.graylog.org/enterprise/>`_. 
+If you have done a manual installation or want to include only parts of the enterprise plugins you can get the tarball from `the Graylog Enterprise web page <https://www.graylog.org/enterprise/>`_. 
 
 The tarball includes the enterprise plugin JAR files.
 
@@ -158,10 +158,10 @@ License Installation
 
 The Graylog Enterprise plugins require a valid license to use the additional features.
 
-Once you have `optained a license <https://www.graylog.org/enterprise/>`_
+Once you have `obtained a license <https://www.graylog.org/enterprise/>`_
 you can import it into your Graylog setup by going through the following steps.
 
-#. As an admin user, open the System/License page from the menu in the web interface.
+#. As an admin user, open the System / License page from the menu in the web interface.
 #. Click the Import new license button in the top right hand corner.
 #. Copy the license text from the confirmation email and paste it into the text field.
 #. The license should be valid and a preview of your license details should appear below the text field.

--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -64,7 +64,7 @@ All packages are located at `https://packages.graylog2.org <https://packages.gra
 DEB
 ~~~
 
-Download the plugins `from the repository <https://packages.graylog2.org/debian/pool/stable/2.4/g/graylog-enterprise-plugins>`_ and transfer them to the server. Use the following command to install the plugins via dpkg.
+Download the plugins `from the deb repository <https://packages.graylog2.org/debian/pool/stable/2.4/g/graylog-enterprise-plugins>`_ and transfer them to the server. Use the following command to install the plugins via dpkg.
 
 ::
 
@@ -73,7 +73,7 @@ Download the plugins `from the repository <https://packages.graylog2.org/debian/
 RPM
 ~~~
 
-Download the plugins `from the repository <https://packages.graylog2.org/el/stable/2.4/x86_64>`_ and transfer them to the server. Use the following command to install the plugins via rpm.
+Download the plugins `from the rpm repository <https://packages.graylog2.org/el/stable/2.4/x86_64>`_ and transfer them to the server. Use the following command to install the plugins via rpm.
 
 ::
 

--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -64,7 +64,7 @@ When the usage of online repositorys is not possible in your environment, you ca
 DEB
 ~~~
 
-The installation on distributions like Debian or Ubuntu could be done with *apt-get* as installation tool from the previous installed online repository.  
+The installation on distributions like Debian or Ubuntu can be done with *apt-get* as installation tool from the previous installed online repository.  
 
 ::
   
@@ -74,7 +74,7 @@ The installation on distributions like Debian or Ubuntu could be done with *apt-
 RPM
 ~~~
 
-The installation on distributions like CentOS or RedHat could be done with *yum* as installation tool from the previous installed online repository.
+The installation on distributions like CentOS or RedHat can be done with *yum* as installation tool from the previous installed online repository.
 
 ::
   


### PR DESCRIPTION
since we have some changed details in Graylog 2.4 and the Installation of Enterprise Packages, that is now visible in the documentation.

All License questions are redirecting to graylog.org/enterprise. If the final location for the .tar is choosen that need to be set too.