### PR TITLE
Update installation.rst

### DIFF
--- a/pages/installation.rst
+++ b/pages/installation.rst
@@ -43,3 +43,4 @@ The Graylog server application has the following prerequisites:
 * Oracle Java SE 8 (OpenJDK 8 also works; latest stable update is recommended)
 
 .. caution:: Graylog prior to 2.3 **does not** work with Elasticsearch 5.x!
+.. caution:: Graylog 2.4 **does not** work with Elasticsearch 6.x yet!


### PR DESCRIPTION
ElasticSeach 6 is not suported yet. But the docu does not tell you.
https://community.graylog.org/t/deflector-exists-as-an-index-and-is-not-an-alias-reopen/3463/3