### PR TITLE
Add FAQ item for how to fix deflector alias in Elasticsearch

### DIFF
--- a/pages/configuration/index_model.rst
+++ b/pages/configuration/index_model.rst
@@ -1,3 +1,5 @@
+.. _index_model:
+
 ***********
 Index model
 ***********


### PR DESCRIPTION
The problem of deflector aliases existing as Elasticsearch indices comes up fairly often.

This PR adds an item to the FAQ's troubleshooting section which explains how to fix the issue on a high-level (i. e. not copy & paste).

Refs https://community.graylog.org/t/messages-getting-updated-in-graylog-deflector/4109