### PR TITLE
Update MongoDB install section

### DIFF
--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -19,9 +19,12 @@ If you're starting from a minimal server setup, you will need to install these a
 MongoDB
 -------
 
-The version of MongoDB included in Debian Jessie is recent enough to be used with Graylog 2.3.x and higher::
+The official MongoDB repository provides the most up-to-date version and is the recommended way of installing MongoDB::
 
-  $ sudo apt install mongodb-server
+  $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 58712A2291FA4AD5
+  $ echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+  $ sudo apt-get update
+  $ sudo apt-get install -y mongodb-org
 
 
 Elasticsearch


### PR DESCRIPTION
Updated MongoDB install section to reflect using the latest official package on Ubuntu from the MongoDB maintainers, rather than point people to an ancient version that is prohibitive to upgrade.