### PR TITLE
Update lookuptables.rst

### DIFF
--- a/pages/lookuptables.rst
+++ b/pages/lookuptables.rst
@@ -39,10 +39,12 @@ and do not have to implement it on their own.
 
 Cache implementations are pluggable and new ones can be added through plugins.
 
-.. note:: The CSV file adapter reads the entire file into memory and refreshes
-          its contents within each check interval if the file was changed.
-          If the cache was purged but the check interval has not elapsed,
-          lookups might return expired values.
+.. important:: The CSV file adapter reads the entire contents of the file into
+               HEAP memory. Ensure that you size the HEAP accordingly.
+
+.. note:: The CSV file adapter refreshes its contents within each check interval
+          if the file was changed. If the cache was purged but the check interval
+          has not elapsed, lookups might return expired values.
 
 Lookup Tables
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Updated to make clear that the lookup tables use HEAP memory, and that it must be sized accordingly.