### PR TITLE
Enable MongoDB during operating system startup

### DIFF
--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -27,6 +27,13 @@ The official MongoDB repository provides the most up-to-date version and is the 
   $ sudo apt-get install -y mongodb-org
 
 
+The last step is to enable MongoDB during the operating system's startup::
+
+  $ sudo systemctl daemon-reload
+  $ sudo systemctl enable mongod.service
+  $ sudo systemctl restart mongod.service
+  
+
 Elasticsearch
 -------------
 

--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -27,6 +27,13 @@ The official MongoDB repository provides the most up-to-date version and is the 
     $ sudo apt-get install -y mongodb-org
 
 
+The last step is to enable MongoDB during the operating system's startup::
+
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable mongod.service
+    $ sudo systemctl restart mongod.service
+    
+
 Elasticsearch
 -------------
 


### PR DESCRIPTION
I added a description to enable MongoDB during operating system startup. I found out this wasn't covered in the installation guide for Ubuntu, though it is covered for Elasticsearch and Graylog. It took me quite some time to figure out why Graylog wasn't starting up before I discovered it was due to MongoDB not being started. Maybe I overlooked something, but maybe this can prevent other users from facing the same problems in the future.