### PR TITLE
link to releases

### DIFF
--- a/pages/getting_started/download.rst
+++ b/pages/getting_started/download.rst
@@ -1,6 +1,6 @@
 Download Graylog
 ----------------
 
-Point your favorite browser to our `virtual appliance download page <https://packages.graylog2.org/appliances/ova>`_ and get the latest stable version. If you are unsure what the latest stable version number is, take a look at our `release page <https://www.graylog.org/releases>`__.
+Point your favorite browser to our `virtual appliance download page <https://packages.graylog2.org/appliances/ova>`_ and get the latest stable version. If you are unsure what the latest stable version number is, take a look at our `release page <http://docs.graylog.org/en/latest/pages/changelog.html>`__.
 
 .. image:: /images/gs/download.png


### PR DESCRIPTION
currentliy 404's so change to working link, or if preferred SSL use githubs https://github.com/Graylog2/graylog2-server/releases 
since HTTPS with https://docs.graylog.org/ complains about SSL_ERROR_BAD_CERT_DOMAIN (*.)readthedocs.org