### PR TITLE
modified first start table to be initsystem based

### DIFF
--- a/pages/collector_sidecar.rst
+++ b/pages/collector_sidecar.rst
@@ -280,13 +280,19 @@ First start
 Once you installed the Sidecar package you are ready to start the service for the first time. Decide which backend you want to use. Enable or disable the single
 backends by setting ``enabled: true`` or respectively to ``false``. Now start the Sidecar, depending on your operating system you can do this with:
 
-+---------------+---------------------------------------------------------------------------------------------+
-| Debian/Ubuntu | ``sudo start collector-sidecar``                                                            |
-+---------------+---------------------------------------------------------------------------------------------+
-| RedHat/CentOS | ``sudo systemctl start collector-sidecar``                                                  |
-+---------------+---------------------------------------------------------------------------------------------+
-| Windows       | ``C:\Program Files\graylog\collector-sidecar\graylog-collector-sidecar.exe -service start`` |
-+---------------+---------------------------------------------------------------------------------------------+
++-------------+----------------------------------------------------------------------------------------------+
+| systemd     | ``sudo systemctl start collector-sidecar``                                                   |
++-------------+----------------------------------------------------------------------------------------------+
+| SysV        | ``sudo start collector-sidecar``                                                             |
++-------------+----------------------------------------------------------------------------------------------+
+| Windows     | ``C:\Program Files\graylog\collector-sidecar\graylog-collector-sidecar.exe -service start``  |
++-------------+----------------------------------------------------------------------------------------------+
+
+If you're unsure which init system your Linux distribution is using, execute the following command to print the name of the used init system::
+
+    # ps -h -o comm -p 1
+
+Otherwise please refer to the handbook of your Linux distribution and look up which init system is being used.
 
 Afterwards you will most likely see an error like this in the log file::
 


### PR DESCRIPTION
PR for bug #446. I think since upstart was only used in Ubuntu which has since switched to SystemD since 2015 then it's pretty safe to assume most users aren't using it anymore. Also mostly due to the fact that a .conf file will be required to setup the upstart process so it's not as simple as the other initsystems.

However, if anyone thinks it should be included then I'll add it. I would just ask someone let me know how I should go about adding it to the project. Create instructions below the table on how to create a upstart .conf file for Graylog ?

Lastly, I know there's a trade off to listing initsystems vs distros (before it was distros) but I think this is much better to maintain since some distros recently switched so someone running older version of a distro could be running an initsystem that isn't specified in the table.

note: this is my first PR so if I've done anything wrong please let me know. I was unable to find a contributing portion in the readme which perhaps would have helped a new contributors.