### PR TITLE
Add Note clarifying that newline escape sequences should be used

### DIFF
--- a/pages/gelf.rst
+++ b/pages/gelf.rst
@@ -114,6 +114,7 @@ This is an example GELF message payload. Any graylog-server node accepts and sto
 uncompressed over a plain socket (without newlines).
 
 .. note:: Newlines must be denoted with the ``\n`` escape sequence to ensure the payload is valid JSON as per `RFC 7159 <https://tools.ietf.org/html/rfc7159#page-8>`_.
+
 ::
 
   {

--- a/pages/gelf.rst
+++ b/pages/gelf.rst
@@ -111,7 +111,10 @@ Example payload
 ===============
 
 This is an example GELF message payload. Any graylog-server node accepts and stores this as a message when GZIP/ZLIB compressed or even when sent
-uncompressed over a plain socket (without newlines)::
+uncompressed over a plain socket (without newlines).
+
+.. note:: Newlines must be denoted with the ``\n`` escape sequence to ensure the payload is valid JSON as per `RFC 7159 <https://tools.ietf.org/html/rfc7159#page-8>`_.
+::
 
   {
     "version": "1.1",


### PR DESCRIPTION
Minor change that clarifies that newline escape sequences should be used instead of actual new line control characters. Also included link to relevant JSON RFC. 

Addresses issue #154 