### PR TITLE
Remove reference to old server.conf parameters

### DIFF
--- a/pages/secure/sec_graylog_beats.rst
+++ b/pages/secure/sec_graylog_beats.rst
@@ -53,7 +53,7 @@ Graylog
 HTTPS
 ^^^^^
 
-Place the ``.key`` and ``.crt`` file on your Graylog server in the configuration dir (/etc/graylog/server/) and add them to the Graylog server.conf. In addition change the ``http_enable_tls`` to **true**. You might need to cover other settings in a multinode cluster or special setups - just read the comments of the settings inside of the server.conf.
+Place the ``.key`` and ``.crt`` file on your Graylog server in the configuration dir (/etc/graylog/server/) and add them to the Graylog server.conf. In addition change ``http_enable_tls`` to **true**. You might need to cover other settings in a multinode cluster or special setups - just read the comments of the settings inside of the server.conf.
 
 When using the collector-sidecar, use the **https** URI in the ``sidecar_configuration.yml``.
 

--- a/pages/secure/sec_graylog_beats.rst
+++ b/pages/secure/sec_graylog_beats.rst
@@ -53,7 +53,7 @@ Graylog
 HTTPS
 ^^^^^
 
-Place the ``.key`` and ``.crt`` file on your Graylog server in the configuration dir (/etc/graylog/server/) and add them to the Graylog server.conf. In addition change the ``rest_listen_uri`` and ``web_listen_uri`` to **https**. You might need to cover other settings in a multinode cluster or special setups - just read the comments of the settings inside of the server.conf.
+Place the ``.key`` and ``.crt`` file on your Graylog server in the configuration dir (/etc/graylog/server/) and add them to the Graylog server.conf. In addition change the ``http_enable_tls`` to **true**. You might need to cover other settings in a multinode cluster or special setups - just read the comments of the settings inside of the server.conf.
 
 When using the collector-sidecar, use the **https** URI in the ``sidecar_configuration.yml``.
 


### PR DESCRIPTION
rest_listen_uri and web_listen_uri are gone.
We configure TLS with http_enable_tls instead.