### PR TITLE
Updated Versions

### DIFF
--- a/pages/installation.rst
+++ b/pages/installation.rst
@@ -38,8 +38,8 @@ System requirements
 The Graylog server application has the following prerequisites:
 
 * Some modern Linux distribution (Debian Linux, Ubuntu Linux, or CentOS recommended)
-* `Elasticsearch 2.3.5 or later <https://www.elastic.co/downloads/elasticsearch>`_
-* `MongoDB 2.4 or later <https://docs.mongodb.org/manual/administration/install-on-linux/>`_ (latest stable version is recommended)
+* `Elasticsearch 5 or later <https://www.elastic.co/downloads/elasticsearch>`_
+* `MongoDB 3.6 or later <https://docs.mongodb.org/manual/administration/install-on-linux/>`_ (latest stable version is recommended)
 * Oracle Java SE 8 (OpenJDK 8 also works; latest stable update is recommended)
 
 .. caution:: Graylog prior to 2.3 **does not** work with Elasticsearch 5.x!

--- a/pages/installation/operating_system_packages.rst
+++ b/pages/installation/operating_system_packages.rst
@@ -23,9 +23,9 @@ Prerequisites
 
 Make sure to install and configure the following software before installing and starting any Graylog services:
 
-* Java (>= 8)
-* MongoDB (>= 2.4)
-* Elasticsearch (>= 2.x)
+* Java (8)
+* MongoDB (>= 3.6)
+* Elasticsearch (>= 5.x)
 
 .. caution:: Graylog 2.3 **does not** work with Elasticsearch 6.x!
 

--- a/pages/installation/os/centos.rst
+++ b/pages/installation/os/centos.rst
@@ -20,14 +20,14 @@ If you want to use ``pwgen`` later on you need to Setup `EPEL <https://fedorapro
 MongoDB
 -------
 
-Installing MongoDB on CentOS should follow `the tutorial for RHEL and CentOS <https://docs.mongodb.com/master/tutorial/install-mongodb-on-red-hat>`_ from the MongoDB documentation. First add the repository file ``/etc/yum.repos.d/mongodb-org-3.2.repo`` with the following contents::
+Installing MongoDB on CentOS should follow `the tutorial for RHEL and CentOS <https://docs.mongodb.com/master/tutorial/install-mongodb-on-red-hat>`_ from the MongoDB documentation. First add the repository file ``/etc/yum.repos.d/mongodb-org-3.6.repo`` with the following contents::
 
-  [mongodb-org-3.2]
+  [mongodb-org-3.6]
   name=MongoDB Repository
-  baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.2/x86_64/
+  baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/x86_64/
   gpgcheck=1
   enabled=1
-  gpgkey=https://www.mongodb.org/static/pgp/server-3.2.asc
+  gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc
 
 After that, install the latest release of MongoDB with ``sudo yum install mongodb-org``.
 

--- a/pages/installation/os/centos.rst
+++ b/pages/installation/os/centos.rst
@@ -133,11 +133,3 @@ Multiple Server Setup
 
 If you plan to have multiple server taking care of different roles in your cluster :ref:`like we have in this big production setup <big_production_setup>` you need to modify only a few settings. This is covered in our :ref:`Multi-node Setup guide<configure_multinode>`. The :ref:`default file location guide <default_file_location>` will give you the file you need to modify in your setup.
 
-
-Feedback
---------
-
-Please file a `bug report in the GitHub repository for the operating system packages <https://github.com/Graylog2/fpm-recipes>`__ if you
-run into any packaging related issues.
-
-If you found this documentation confusing or have more questions, please open an `issue in the Github repository for the documentation <https://github.com/Graylog2/documentation/issues>`__.

--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -19,16 +19,19 @@ If you're starting from a minimal server setup, you will need to install these a
 MongoDB
 -------
 
-The version of MongoDB included in Debian Jessie is recent enough to be used with Graylog 2.3.x and higher::
+The official MongoDB repository provides the most up-to-date version and is the recommended way of installing MongoDB::
 
-  $ sudo apt install mongodb-server
+    $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+    $ echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+    $ sudo apt-get update
+    $ sudo apt-get install -y mongodb-org
 
 
 The last step is to enable MongoDB during the operating system's startup::
 
-  $ sudo systemctl daemon-reload
-  $ sudo systemctl enable mongod.service
-  $ sudo systemctl restart mongod.service
+    $ sudo systemctl daemon-reload
+    $ sudo systemctl enable mongod.service
+    $ sudo systemctl restart mongod.service
   
 
 Elasticsearch

--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -88,11 +88,3 @@ Multiple Server Setup
 
 If you plan to have multiple server taking care of different roles in your cluster :ref:`like we have in this big production setup <big_production_setup>` you need to modify only a few settings. This is covered in our :ref:`Multi-node Setup guide<configure_multinode>`. The :ref:`default file location guide <default_file_location>` will give you the file you need to modify in your setup.
 
-
-Feedback
---------
-
-Please file a `bug report in the GitHub repository for the operating system packages <https://github.com/Graylog2/fpm-recipes>`__ if you
-run into any packaging related issues.
-
-If you found this documentation confusing or have more questions, please open an `issue in the Github repository for the documentation <https://github.com/Graylog2/documentation/issues>`__.

--- a/pages/installation/os/sles.rst
+++ b/pages/installation/os/sles.rst
@@ -25,10 +25,10 @@ Assuming a minimal setup, you have to install the Java runtime environment::
 MongoDB
 -------
 
-Installing MongoDB on SLES should follow `the tutorial for SLES <https://docs.mongodb.com/v3.4/tutorial/install-mongodb-on-suse/>`_ from the MongoDB documentation. Add the GPG key and the repository before installing MongoDB::
+Installing MongoDB on SLES should follow `the tutorial for SLES <https://docs.mongodb.com/v3.6/tutorial/install-mongodb-on-suse/>`_ from the MongoDB documentation. Add the GPG key and the repository before installing MongoDB::
 
-  $ sudo rpm --import https://www.mongodb.org/static/pgp/server-3.4.asc
-  $ sudo zypper addrepo --gpgcheck "https://repo.mongodb.org/zypper/suse/12/mongodb-org/3.4/x86_64/" mongodb
+  $ sudo rpm --import https://www.mongodb.org/static/pgp/server-3.6.asc
+  $ sudo zypper addrepo --gpgcheck "https://repo.mongodb.org/zypper/suse/12/mongodb-org/3.6/x86_64/" mongodb
   $ sudo zypper -n install mongodb-org
 
 In order to automatically start MongoDB on system boot, you have to activate the MongoDB service by running the following commands::

--- a/pages/installation/os/sles.rst
+++ b/pages/installation/os/sles.rst
@@ -105,10 +105,4 @@ Cluster Setup
 
 If you plan to have multiple servers assuming different roles in your cluster :ref:`like we have in this big production setup <big_production_setup>` you need to modify only a few settings. This is covered in our :ref:`Multi-node Setup guide<configure_multinode>`. The :ref:`default file location guide <default_file_location>` lists the locations of the files you need to modify.
 
-Feedback
---------
 
-Please file a `bug report in the GitHub repository for the operating system packages <https://github.com/Graylog2/fpm-recipes>`__ if you
-run into any packaging related issues.
-
-If you found this documentation confusing or have more questions, please open an `issue in the Github repository for the documentation <https://github.com/Graylog2/documentation/issues>`__.

--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -89,10 +89,4 @@ Multiple Server Setup
 If you plan to have multiple server taking care of different roles in your cluster :ref:`like we have in this big production setup <big_production_setup>` you need to modify only a few settings. This is covered in our :ref:`Multi-node Setup guide<configure_multinode>`. The :ref:`default file location guide <default_file_location>` will give you the file you need to modify in your setup.
 
 
-Feedback
---------
 
-Please file a `bug report in the GitHub repository for the operating system packages <https://github.com/Graylog2/fpm-recipes>`__ if you
-run into any packaging related issues.
-
-If you found this documentation confusing or have more questions, please open an `issue in the Github repository for the documentation <https://github.com/Graylog2/documentation/issues>`__.


### PR DESCRIPTION
I updated the minimal Versions for GL 3 to what we have talked today. What is MongoDB 3.6 and Elasticsearch 5.6 in all installation documentation.

This way all fresh installations will have this new minimal (when just copy&paste from the docs)