### PR TITLE
Fix debug log FAQ

### DIFF
--- a/pages/faq.rst
+++ b/pages/faq.rst
@@ -301,7 +301,10 @@ difficult to review log messages for a particular area of concern).
 Graylog supports the ability to enable ``debug`` or ``trace`` logging for specific application areas or plugins. To do this,
 execute the following terminal command against a particular Graylog node.::
 
-  curl -I -X PUT http://<graylog-username>:<graylog-password>@<graylog-node-ip>:9000/api/system/loggers/<application-package>/level/debug
+  curl -I -X PUT http://<graylog-username>:<graylog-password>@<graylog-node-ip>:9000/api/system/loggers/<application-package>/level/debug \
+  -H 'X-Requested-By: graylog-api-user' \
+  -X PUT \
+  -I
 
 .. note:: The ``application-package`` is the Java package for the area of concern (eg. ``org.graylog.aws``  for the AWS plugin or ``org.graylog2.lookup`` for Lookup Tables). You might need to look at the Graylog source code to identify the desired application-package.
 


### PR DESCRIPTION
The `curl` command to enable debug logging for a plugin was incorrect (was missing a few arguments). I have fixed and tested it.

![screen shot 2018-11-15 at 4 35 53 pm](https://user-images.githubusercontent.com/3423655/48586123-a3a58c80-e8f4-11e8-9f96-32362a5c2460.png)
