### PR TITLE
Add built-in Data Adaptors documentation (mostly for DNS Lookup)

### DIFF
--- a/pages/lookuptables.rst
+++ b/pages/lookuptables.rst
@@ -176,18 +176,18 @@ of the lookup result, the second returns the **single value**.
 
 .. image:: /images/lookuptables/usage-pipeline-rule.png
 
-Built-in Data Adaptors
+Built-in Data Adapters
 ----------------------
 
-The following Data Adaptors are shipped with Graylog by default. Detailed on-screen documentation for each is available
-on the Add/Edit Data Adaptor page in Graylog.
+The following Data Adapters are shipped with Graylog by default. Detailed on-screen documentation for each is available
+on the Add/Edit Data Adapter page in Graylog.
 
-CSV File Adaptor
+CSV File Adapter
 ^^^^^^^^^^^^^^^^
 
 Preforms key/value lookups from a CSV file.
 
-DNS Lookup Adaptor
+DNS Lookup Adapter
 ^^^^^^^^^^^^^^^^^^
 
 Provides the ability to perform the following types of DNS resolutions:
@@ -198,11 +198,11 @@ Provides the ability to perform the following types of DNS resolutions:
 - Reverse lookup (PTR record)
 - Text lookup (TXT records)
 
-DSV File from HTTP Adaptor
+DSV File from HTTP Adapter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Performs key/value from a DSV file. This adaptor supports more advanced customization than the
-CSV File adaptor (such a custom delimiter and customizable key/value columns).
+Performs key/value from a DSV file. This adapter supports more advanced customization than the
+CSV File adapter (such a custom delimiter and customizable key/value columns).
 
 HTTP JSONPath Adapter
 ^^^^^^^^^^^^^^^^^^^^^

--- a/pages/lookuptables.rst
+++ b/pages/lookuptables.rst
@@ -175,3 +175,36 @@ There are two lookup functions that can be used in a pipeline rule,
 of the lookup result, the second returns the **single value**.
 
 .. image:: /images/lookuptables/usage-pipeline-rule.png
+
+Built-in Data Adaptors
+----------------------
+
+The following Data Adaptors are shipped with Graylog by default. Detailed on-screen documentation for each is available
+on the Add/Edit Data Adaptor page in Graylog.
+
+CSV File Adaptor
+^^^^^^^^^^^^^^^^
+
+Preforms key/value lookups from a CSV file.
+
+DNS Lookup Adaptor
+^^^^^^^^^^^^^^^^^^
+
+Provides the ability to perform the following types of DNS resolutions:
+
+- Resolve hostname to IPv4 address (A records)
+- Resolve hostname to IPv6 address (AAAA records)
+- Resolve hostname to IPv4 and IPv6 address (A and AAAA records)
+- Reverse lookup (PTR record)
+- Text lookup (TXT records)
+
+DSV File from HTTP Adaptor
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Performs key/value from a DSV file. This adaptor supports more advanced customization than the
+CSV File adaptor (such a custom delimiter and customizable key/value columns).
+
+HTTP JSONPath Adapter
+^^^^^^^^^^^^^^^^^^^^^
+
+Executes HTTP GET requests to lookup a key and parses the result based on configured JSONPath expressions.


### PR DESCRIPTION
Add a section in the docs that discusses build-in data adaptors, so that we can have some place in the docs that discusses the DNS Lookup adaptor (@lennartkoopmann will reference from blog post).

![image](https://user-images.githubusercontent.com/3423655/49260858-16d6f480-f405-11e8-9884-a88a92171431.png)
