### PR TITLE
fix ES state yellow description

### DIFF
--- a/pages/configuration/elasticsearch.rst
+++ b/pages/configuration/elasticsearch.rst
@@ -523,9 +523,7 @@ YELLOW
 
 The YELLOW status means that all of the primary shards are available but some or all shard replicas are not.
 
-With only one Elasticsearch node, the cluster state cannot become green because shard replicas cannot be assigned.
-
-In most cases, this can be solved by adding another Elasticsearch node to the cluster or by reducing the replication factor of the indices (which means less resiliency against node outages, though).
+When the index configuration include replication with a count that is equal or higher than the number of nodes, your cluster cannot become green. In most cases, this can be solved by adding another Elasticsearch node to the cluster or by reducing the replication factor of the indices.
 
 
 GREEN

--- a/pages/configuration/elasticsearch.rst
+++ b/pages/configuration/elasticsearch.rst
@@ -523,7 +523,7 @@ YELLOW
 
 The YELLOW status means that all of the primary shards are available but some or all shard replicas are not.
 
-When the index configuration include replication with a count that is equal or higher than the number of nodes, your cluster cannot become green. In most cases, this can be solved by adding another Elasticsearch node to the cluster or by reducing the replication factor of the indices.
+When the index configuration includes replication with a count that is equal or higher than the number of nodes, your cluster cannot become green. In most cases, this can be solved by adding another Elasticsearch node to the cluster or by reducing the replication factor of the indices.
 
 
 GREEN


### PR DESCRIPTION
This changes the text for yellow ES state. Now it should be more clear.

FIX: https://github.com/Graylog2/documentation/issues/504

This need to be ported to 3.0