### PR TITLE
Warn about the now required X-Requested-By header (#517)

### DIFF
--- a/pages/archiving/usage.rst
+++ b/pages/archiving/usage.rst
@@ -57,7 +57,7 @@ do this.
 
 An index can be archived with a simple curl command::
 
-   $ curl -s -u admin -X POST http://127.0.0.1:9000/api/plugins/org.graylog.plugins.archive/archives/graylog_386
+   $ curl -s -u admin -H 'X-Requested-By: cli' -X POST http://127.0.0.1:9000/api/plugins/org.graylog.plugins.archive/archives/graylog_386
    Enter host password for user 'admin': ***************
    {
       "archive_job_config" : {
@@ -133,7 +133,7 @@ REST API
 As with archive creation you can also use the REST API to restore an
 archived index into the Elasticsearch cluster::
 
-   $ curl -s -u admin -X POST http://127.0.0.1:9000/api/plugins/org.graylog.plugins.archive/archives/graylog_386/restore
+   $ curl -s -u admin -H 'X-Requested-By: cli' -X POST http://127.0.0.1:9000/api/plugins/org.graylog.plugins.archive/archives/graylog_386/restore
    Enter host password for user 'admin': ***************
    {
       "archive_metadata": {

--- a/pages/configuration/rest_api.rst
+++ b/pages/configuration/rest_api.rst
@@ -33,6 +33,9 @@ Naturally, the same operations the API browser offers can be used on the command
 .. note::
    In the following examples, the username ``GM`` and password ``superpower`` will be used to demonstrate how to work with the Graylog REST API running at ``http://192.168.178.26:9000/api``.
 
+.. warning::
+   Since Graylog 2.5.0, all non-GET API requests **must include and set a value** for the ``X-Requested-By`` HTTP header. This is needed to prevent CSRF attacks.
+
 
 The following command displays Graylog cluster information as JSON, exactly the same information the web interface is displaying on the *System / Nodes* page::
 
@@ -99,7 +102,7 @@ In order to create a new access token, you need to send a ``POST`` request to th
 
 The following example will create an access token named ``icinga`` for the user ``GM``::
 
-    curl -u GM:superpower -H 'Accept: application/json' -X POST 'http://192.168.178.26:9000/api/users/GM/tokens/icinga?pretty=true'
+    curl -u GM:superpower -H 'Accept: application/json' -H 'X-Requested-By: cli' -X POST 'http://192.168.178.26:9000/api/users/GM/tokens/icinga?pretty=true'
 
 The response will include the access token in the ``token`` field::
 
@@ -125,7 +128,7 @@ When an access token is no longer needed, it can be delete on the Graylog REST A
 
 The following example deletes the previously created access token ``htgi84ut7jpivsrcldd6l4lmcigvfauldm99ofcb4hsfcvdgsru`` of the user ``GM``::
 
-    curl -u GM:superpower -H 'Accept: application/json' -X DELETE' http://192.168.178.26:9000/api/users/GM/tokens/ap84p4jehbf2jddva8rdmjr3k7m3kdnuqbai5s0h5a48e7069po?pretty=true'
+    curl -u GM:superpower -H 'Accept: application/json' -H 'X-Requested-By: cli' -X DELETE' http://192.168.178.26:9000/api/users/GM/tokens/ap84p4jehbf2jddva8rdmjr3k7m3kdnuqbai5s0h5a48e7069po?pretty=true'
 
 
 Creating and using Session Token
@@ -135,7 +138,7 @@ While access tokens can be used for permanent access, session tokens will expire
 
 Getting a new session token can be obtained  via ``POST`` request to the Graylog REST API. Username and password are required to get a valid session ID. The following example will create an session token for the user ``GM``::
 
-    curl -i -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' 'http://192.168.178.26:9000/api/system/sessions' -d '{"username":"GM", "password":"superpower", "host":""}'
+    curl -i -X POST -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'X-Requested-By: cli' 'http://192.168.178.26:9000/api/system/sessions' -d '{"username":"GM", "password":"superpower", "host":""}'
 
 The response will include the session token in the field ``session_id`` and the time of expiration::
 

--- a/pages/faq.rst
+++ b/pages/faq.rst
@@ -196,7 +196,7 @@ Send a POST request via the Graylog API Browser or curl to the ``/roles`` resour
 
 The following curl command will create the required role (modify the URL of the Graylog REST API, here ``http://127.0.0.1:9000/api/``, and the user credentials, here ``admin``/``admin``, according to your setup)::
   
-  $ curl -u admin:admin -H "Content-Type: application/json" -X POST -d '{"name": "Metrics Access", "description": "Provides read access to all system metrics", "permissions": ["metrics:*"], "read_only": false}' 'http://127.0.0.1:9000/api/roles'
+  $ curl -u admin:admin -H "Content-Type: application/json" -H 'X-Requested-By: cli' -X POST -d '{"name": "Metrics Access", "description": "Provides read access to all system metrics", "permissions": ["metrics:*"], "read_only": false}' 'http://127.0.0.1:9000/api/roles'
 
 
 Troubleshooting

--- a/pages/users_and_roles/permission_system.rst
+++ b/pages/users_and_roles/permission_system.rst
@@ -45,7 +45,7 @@ Creating the role
 
 You can create a new role using the REST API like this::
 
-  curl -v -XPOST -u ADMIN:PASSWORD -H 'Content-Type: application/json' 'http://graylog.example.org:9000/api/roles' -d '{"read_only": false,"permissions": ["processing:changestate"],"name": "Change processing state","description": "Permission to start or stop processing on Graylog nodes"}'
+  curl -v -XPOST -u ADMIN:PASSWORD -H 'Content-Type: application/json' -H 'X-Requested-By: cli' 'http://graylog.example.org:9000/api/roles' -d '{"read_only": false,"permissions": ["processing:changestate"],"name": "Change processing state","description": "Permission to start or stop processing on Graylog nodes"}'
 
 Notice the ``processing:changestate`` permission that we assigned. Every user with this role will be able to start and
 stop processing on ``graylog-server`` nodes. Graylog's standard ``reader`` permissions do not provide any access to data


### PR DESCRIPTION
This header is required since Graylog 2.5.0 for all non-GET API requests to prevent CSRF attacks.
This change adds a warning in the REST API page, and adapts our examples to include the header.

Cherry-pick from #517