### PR TITLE
Note on Graylog Password Secret

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -100,7 +100,7 @@ Example::
     graylog:
       image: graylog/graylog:2.5
       environment:
-        # CHANGE ME!
+        # CHANGE ME (must be at least 16 characters)!
         - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
         # Password: admin
         - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
@@ -239,7 +239,7 @@ Using Docker volumes for the data of MongoDB, Elasticsearch, and Graylog, the ``
       volumes:
         - graylog_journal:/usr/share/graylog/data/journal
       environment:
-        # CHANGE ME!
+        # CHANGE ME (must be at least 16 characters)!
         - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
         # Password: admin
         - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918


### PR DESCRIPTION
Added a comment in the docker-compose file regarding the GRAYLOG_PASSWORD_SECRET.

The minimum length is 16 characters.