### PR TITLE
added ES6, OSS packages and upgrade/reindex

### DIFF
--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -52,7 +52,9 @@ The following list shows the minimum required Graylog versions for the Graylog E
       - 2.4.6
     * - 2.5.0
       - 2.5.0
-
+    * - 2.5.1
+      - 2.5.1
+    
 
 Installation
 ============
@@ -106,18 +108,18 @@ If you have done a manual installation or want to include only parts of the ente
 
     * - Enterprise Version
       - Download URL
-    * - 2.5.0
-      - :enterprise-plugins-tar:`2.5.0`
+    * - 2.5.1
+      - :enterprise-plugins-tar:`2.5.1`
 
 The tarball includes the enterprise plugin JAR files.
 
 ::
 
-  $ tar -tzf graylog-enterprise-plugins-2.5.0.tgz
-    graylog-enterprise-plugins-2.5.0/LICENSE
-    graylog-enterprise-plugins-2.5.0/plugin/graylog-plugin-archive-2.5.0.jar
-    graylog-enterprise-plugins-2.5.0/plugin/graylog-plugin-auditlog-2.5.0.jar
-    graylog-enterprise-plugins-2.5.0/plugin/graylog-plugin-license-2.5.0.jar
+  $ tar -tzf graylog-enterprise-plugins-2.5.1.tgz
+    graylog-enterprise-plugins-2.5.1/LICENSE
+    graylog-enterprise-plugins-2.5.1/plugin/graylog-plugin-archive-2.5.1.jar
+    graylog-enterprise-plugins-2.5.1/plugin/graylog-plugin-auditlog-2.5.1.jar
+    graylog-enterprise-plugins-2.5.1/plugin/graylog-plugin-license-2.5.1.jar
 
 Depending on the Graylog setup method you have used, you have to install the plugins into different locations.
 
@@ -131,18 +133,18 @@ Your plugin directory should look similar to this after installing the enterpris
 ::
 
   plugin/
-  ├── graylog-plugin-auditlog-2.5.0.jar
-  ├── graylog-plugin-threatintel-2.5.0.jar
-  ├── graylog-plugin-archive-2.5.0.jar
-  ├── graylog-plugin-beats-2.5.0.jar
-  ├── graylog-plugin-netflow-2.5.0.jar
-  ├── graylog-plugin-aws-2.5.0.jar
-  ├── graylog-plugin-pipeline-processor-2.5.0.jar
-  ├── graylog-plugin-enterprise-integration-2.5.0.jar
-  ├── graylog-plugin-map-widget-2.5.0.jar
-  ├── graylog-plugin-cef-2.5.0.jar
-  ├── graylog-plugin-license-2.5.0.jar
-  └── graylog-plugin-collector-2.5.0.jar
+  ├── graylog-plugin-auditlog-2.5.1.jar
+  ├── graylog-plugin-threatintel-2.5.1.jar
+  ├── graylog-plugin-archive-2.5.1.jar
+  ├── graylog-plugin-beats-2.5.1.jar
+  ├── graylog-plugin-netflow-2.5.1.jar
+  ├── graylog-plugin-aws-2.5.1.jar
+  ├── graylog-plugin-pipeline-processor-2.5.1.jar
+  ├── graylog-plugin-enterprise-integration-2.5.1.jar
+  ├── graylog-plugin-map-widget-2.5.1.jar
+  ├── graylog-plugin-cef-2.5.1.jar
+  ├── graylog-plugin-license-2.5.1.jar
+  └── graylog-plugin-collector-2.5.1.jar
   
 
 
@@ -158,17 +160,17 @@ You should see something like the following in your Graylog server logs. It indi
 
 ::
 
-  2017-12-18T17:39:10.797+01:00 INFO  [CmdLineTool] Loaded plugin: AWS plugins 2.5.0 [org.graylog.aws.plugin.AWSPlugin]
-  2017-12-18T17:39:10.803+01:00 INFO  [CmdLineTool] Loaded plugin: Audit Log 2.5.0 [org.graylog.plugins.auditlog.AuditLogPlugin]
-  2017-12-18T17:39:10.805+01:00 INFO  [CmdLineTool] Loaded plugin: Elastic Beats Input 2.5.0 [org.graylog.plugins.beats.BeatsInputPlugin]
-  2017-12-18T17:39:10.807+01:00 INFO  [CmdLineTool] Loaded plugin: CEF Input 2.5.0 [org.graylog.plugins.cef.CEFInputPlugin]
-  2017-12-18T17:39:10.809+01:00 INFO  [CmdLineTool] Loaded plugin: Collector 2.5.0 [org.graylog.plugins.collector.CollectorPlugin]
-  2017-12-18T17:39:10.811+01:00 INFO  [CmdLineTool] Loaded plugin: Enterprise Integration Plugin 2.5.0 [org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin]
-  2017-12-18T17:39:10.812+01:00 INFO  [CmdLineTool] Loaded plugin: License Plugin 2.5.0 [org.graylog.plugins.license.LicensePlugin]
-  2017-12-18T17:39:10.814+01:00 INFO  [CmdLineTool] Loaded plugin: MapWidgetPlugin 2.5.0 [org.graylog.plugins.map.MapWidgetPlugin]
-  2017-12-18T17:39:10.815+01:00 INFO  [CmdLineTool] Loaded plugin: NetFlow Plugin 2.5.0 [org.graylog.plugins.netflow.NetFlowPlugin]
-  2017-12-18T17:39:10.826+01:00 INFO  [CmdLineTool] Loaded plugin: Pipeline Processor Plugin 2.5.0 [org.graylog.plugins.pipelineprocessor.ProcessorPlugin]
-  2017-12-18T17:39:10.827+01:00 INFO  [CmdLineTool] Loaded plugin: Threat Intelligence Plugin 2.5.0 [org.graylog.plugins.threatintel.ThreatIntelPlugin]
+  2017-12-18T17:39:10.797+01:00 INFO  [CmdLineTool] Loaded plugin: AWS plugins 2.5.1 [org.graylog.aws.plugin.AWSPlugin]
+  2017-12-18T17:39:10.803+01:00 INFO  [CmdLineTool] Loaded plugin: Audit Log 2.5.1 [org.graylog.plugins.auditlog.AuditLogPlugin]
+  2017-12-18T17:39:10.805+01:00 INFO  [CmdLineTool] Loaded plugin: Elastic Beats Input 2.5.1 [org.graylog.plugins.beats.BeatsInputPlugin]
+  2017-12-18T17:39:10.807+01:00 INFO  [CmdLineTool] Loaded plugin: CEF Input 2.5.1 [org.graylog.plugins.cef.CEFInputPlugin]
+  2017-12-18T17:39:10.809+01:00 INFO  [CmdLineTool] Loaded plugin: Collector 2.5.1 [org.graylog.plugins.collector.CollectorPlugin]
+  2017-12-18T17:39:10.811+01:00 INFO  [CmdLineTool] Loaded plugin: Enterprise Integration Plugin 2.5.1 [org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin]
+  2017-12-18T17:39:10.812+01:00 INFO  [CmdLineTool] Loaded plugin: License Plugin 2.5.1 [org.graylog.plugins.license.LicensePlugin]
+  2017-12-18T17:39:10.814+01:00 INFO  [CmdLineTool] Loaded plugin: MapWidgetPlugin 2.5.1 [org.graylog.plugins.map.MapWidgetPlugin]
+  2017-12-18T17:39:10.815+01:00 INFO  [CmdLineTool] Loaded plugin: NetFlow Plugin 2.5.1 [org.graylog.plugins.netflow.NetFlowPlugin]
+  2017-12-18T17:39:10.826+01:00 INFO  [CmdLineTool] Loaded plugin: Pipeline Processor Plugin 2.5.1 [org.graylog.plugins.pipelineprocessor.ProcessorPlugin]
+  2017-12-18T17:39:10.827+01:00 INFO  [CmdLineTool] Loaded plugin: Threat Intelligence Plugin 2.5.1 [org.graylog.plugins.threatintel.ThreatIntelPlugin]
 
 Cluster Setup
 =============

--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -24,7 +24,7 @@ If you simply want to checkout Graylog without any further customization, you ca
   $ docker run --name mongo -d mongo:3
   $ docker run --name elasticsearch \
       -e "http.host=0.0.0.0" -e "xpack.security.enabled=false" \
-      -d docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+      -d docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
   $ docker run --link mongo --link elasticsearch \
       -p 9000:9000 -p 12201:12201 -p 514:514 \
       -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" \
@@ -78,18 +78,11 @@ Example::
       image: mongo:3
     # Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/docker.html
     elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+      image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
       environment:
         - http.host=0.0.0.0
         - transport.host=localhost
         - network.host=0.0.0.0
-        # Disable X-Pack security: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/security-settings.html#general-security-settings
-        - xpack.security.enabled=false
-        - xpack.watcher.enabled=false
-        - xpack.monitoring.enabled=false
-        - xpack.security.audit.enabled=false
-        - xpack.ml.enabled=false
-        - xpack.graph.enabled=false
         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       ulimits:
         memlock:
@@ -142,7 +135,7 @@ For example, setting up the SMTP configuration for sending Graylog alert notific
       image: "mongo:3"
       # Other settings [...]
     elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+      image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
       # Other settings [...]
     graylog:
       image: graylog/graylog:2.5
@@ -182,7 +175,7 @@ This can be done by adding an entry to the `volumes <https://docs.docker.com/com
       image: mongo:3
       # Other settings [...]
     elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+      image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
       # Other settings [...]
     graylog:
       image: graylog/graylog:2.5
@@ -213,20 +206,13 @@ Using Docker volumes for the data of MongoDB, Elasticsearch, and Graylog, the ``
         - mongo_data:/data/db
     # Elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/docker.html
     elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+      image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
       volumes:
         - es_data:/usr/share/elasticsearch/data
       environment:
         - http.host=0.0.0.0
         - transport.host=localhost
         - network.host=0.0.0.0
-        # Disable X-Pack security: https://www.elastic.co/guide/en/elasticsearch/reference/6.x/security-settings.html#general-security-settings
-        - xpack.security.enabled=false
-        - xpack.watcher.enabled=false
-        - xpack.monitoring.enabled=false
-        - xpack.security.audit.enabled=false
-        - xpack.ml.enabled=false
-        - xpack.graph.enabled=false
         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       ulimits:
         memlock:
@@ -301,7 +287,7 @@ The ``docker-compose.yml`` file has to reference the new Docker image::
       image: "mongo:3"
       # Other settings [...]
     elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+      image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
       # Other settings [...]
     graylog:
       image: graylog-with-sso-plugin
@@ -325,7 +311,7 @@ The ``docker-compose.yml`` file has to reference the new Docker image::
       image: "mongo:3"
       # Other settings [...]
     elasticsearch:
-      image: docker.elastic.co/elasticsearch/elasticsearch:6.5.1
+      image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
       # Other settings [...]
     graylog:
       image: graylog/graylog:2.5
@@ -362,4 +348,4 @@ Follow the `documentation for the Graylog image on Docker Hub <https://hub.docke
 
   $ docker run --link mongo --link elasticsearch -p 9000:9000 -p 12201:12201 -p 514:514 \
       -e GRAYLOG_WEB_ENDPOINT_URI="http://127.0.0.1:9000/api" \
-      -d graylog/graylog:2.5.0-1
+      -d graylog/graylog:3.0.0-beta.3-1

--- a/pages/installation/os/centos.rst
+++ b/pages/installation/os/centos.rst
@@ -48,7 +48,7 @@ First install the Elastic GPG key with ``rpm --import https://artifacts.elastic.
 
     [elasticsearch-6.x]
     name=Elasticsearch repository for 6.x packages
-    baseurl=https://artifacts.elastic.co/packages/6.x/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-6.x/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1

--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -41,7 +41,7 @@ Graylog 2.5.x should be used with Elasticsearch 6.x, please follow the installat
 
 
     $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-    $ echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
+    $ echo "deb https://artifacts.elastic.co/packages/oss-6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
     $ sudo apt update && sudo apt install elasticsearch
 
 

--- a/pages/installation/os/sles.rst
+++ b/pages/installation/os/sles.rst
@@ -46,7 +46,7 @@ First install the Elastic GPG key with ``rpm --import https://artifacts.elastic.
 
     [elasticsearch-6.x]
     name=Elasticsearch repository for 6.x packages
-    baseurl=https://artifacts.elastic.co/packages/6.x/yum
+    baseurl=https://artifacts.elastic.co/packages/oss-6.x/yum
     gpgcheck=1
     gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
     enabled=1

--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -41,7 +41,7 @@ Graylog 2.5.x should be used with Elasticsearch 6.x, please follow the installat
 
 
     $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-    $ echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
+    $ echo "deb https://artifacts.elastic.co/packages/oss-6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
     $ sudo apt-get update && sudo apt-get install elasticsearch
 
 Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::

--- a/pages/upgrade.rst
+++ b/pages/upgrade.rst
@@ -25,9 +25,21 @@ Upgrading Graylog Originally Installed from Package
 If the current installation was installed using a package manager (ex. yum, apt), update the repository package to the target version, and use the system tools to upgrade the package.
 For .rpm based systems :ref:`this update guide <operating_package_upgrade_rpm-yum-dnf>` and for .deb based systems :ref:`this update guide <operating_package_upgrade_DEB-APT>` should help.
 
+
+
 Upgrading Elasticsearch
-=======================
+-----------------------
 
 Since Graylog 2.3 Elasticsearch 5.x is supported. This Graylog version supports Elasticsearch 2.x and 5.x. It is recommended to update Elasticsearch 2.x to the latest stable 5.x version, after you have Graylog 2.3 or later running. This Elasticsearch upgrade does not need to be made during the Graylog update. 
 
 When upgrading from Elasticsearch 2.x to Elasticsearch 5.x, make sure to read `the upgrade guide <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/setup-upgrade.html>`_ provided by Elastic. The Graylog :ref:`Elasticsearch configuration documentation <configuring_es>` contains information about the compatible Elasticsearch version. After the upgrade you must :ref:`rotate the indices once manually <rotate_es_indices>`.
+
+Graylog 2.5 is the first Graylog version that supports Elasticsearch 6, the upgrade is recommend as soon as possible but might need more attention and include the need to reindex your data, make sure to check :ref:`our Elasticsearch 6 upgrade notes <es6_reindex>`.
+
+When upgrading from Elasticsearch 5.x to Elasticsearch 6.x, make sure to read the `upgrade guide <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/setup-upgrade.html>`_ provided by Elastic. The Graylog :ref:`Elasticsearch configuration documentation <configuring_es>` contains information about the compatible Elasticsearch version. After the upgrade you must :ref:`rotate the indices once manually <rotate_es_indices>`. 
+
+.. toctree::
+   :titlesonly:
+   :glob:
+
+   upgrade/elasticsearch-*

--- a/pages/upgrade/elasticsearch-6.rst
+++ b/pages/upgrade/elasticsearch-6.rst
@@ -23,7 +23,201 @@ Upgrade without re-index
 
 When no re-index is needed the easiest way is to follow the `elastic upgrade guide for Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/6.5/restart-upgrade.html>`__ this gives all needed commands. 
 
-Upgrade wiht re-index
+Upgrade with re-index
 =====================
 
- 
+First a brief overview what steps need to be performed followed by the list of commands. Once you started the process of reindex your data you need to finish all steps to get a working Graylog and Elasticsearch cluster again. 
+
+
+1. Upgrade to Graylog latest 2.4 release (2.4.6 at time of writing)
+2. Upgrade ES to the latest 5.6.x on all cluster nodes. (5.6.14 as of this writing)
+    * See: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/setup-upgrade.html
+3. Wait until all shards are initialized after updating ES
+    * If the active write index is still a 2.x ES index, a manual index rotation needs to be triggered
+4. Upgrade to Graylog 2.5 (2.5.1 at time of writing)
+5. Update the index template for every index set to the latest ES 6 one by using the Graylog HTTP API. (otherwise a user has to rotate the active write index just to install the latest index template)
+6. Check which indices have been created with ES 2.x and need re-indexing
+    * For each index to re-index do the following
+    	* Check that index is not the active write index
+    	* Create a re-index target index: <index-name>_reindex (e.g. graylog_0_reindex) (with correct settings for shards and replicas)
+    	* Check that mapping and settings of the new index are correct
+    	* Start re-index task in ES (using requests_per_second URL param and size param in the payload to avoid overloading the ES cluster)
+    	* Check progress of re-index task and wait until it is done
+    	* Check that the document counts in the old and the new index match
+    	* Delete old index
+    	* Recreate the old index: <index-name> (e.g. graylog_0) (with correct settings for shards and replicas)
+    	* Check that mapping and settings of the new index are correct
+    	* Start re-index task in ES to re-index documents back into the old index (using requests_per_second URL param and size param in the payload to avoid overloading the ES cluster)
+    	* Check that the document counts in the old and the new index match
+    	* Recreate Graylog index ranges for the old index
+    	* Delete temporary re-index target index (e.g. graylog_0_reindex)
+7. Delete old re-index tasks from ES
+8. Upgrade to the latest ES 6.x version. (6.5.1 as of this writing) 
+   
+Detailed list of commands
+-------------------------
+
+.. note:: This is not a copy&paste tutorial and you need to read and adjust the commands to your local needs. We use the tools `httpie <https://httpie.org/>`__ and `jq <https://stedolan.github.io/jq/>`__ in the following commands.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+Check ES versions of all nodes
+""""""""""""""""""""""""""""""
+The ES version needs to be the same on all ES nodes in the cluster before we can start the re-index process!::
+
+    http ":9200/_cat/nodes?v&h=name,ip,version"
+
+Check that all shards are initialized ("green")
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+All shards need to be initialized before we can start the re-index process.::
+
+    http ":9200/_cat/indices?h=health,status,index" | grep -v '^green'
+
+Update Graylog index templates in Elasticsearch
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+The index templates that Graylog writes to Elasticsearch need to be updated before we can start the re-index process.::
+
+    http post :9000/api/system/indexer/indices/templates/update x-requested-by:httpie
+
+Collect indices that need a re-index to work with ES 6
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+All indices which have not been created with ES 5 need to be re-index to work with ES 6. (or deleted if they are not needed anymore...)::
+
+    http :9200/_settings | jq '[ path(.[] | select(.settings.index.version.created < "5000000"))[] ]'
+
+Re-Index commands for every index
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following commands need to be executed for every index that needs to be re-indexed. Replace the graylog_0 index name in the examples below with the index name you are currently working on.
+
+Check if index is an active write index
+"""""""""""""""""""""""""""""""""""""""
+
+We should never re-index the active write target because that index is actively written to. If the active write index is still a 2.x ES index, a manual index rotation needs to be triggered.::
+
+    http :9200/*_deflector/_alias | jq 'keys'
+
+Create new index
+""""""""""""""""
+
+The new index needs to be created before it can be used as a re-index target. The request needs to include the correct settings for the number of shards and replicas. These settings can be different for each index set! (actual settings can be found in the Graylog "System / Indices" page for each index set)::
+
+    http put :9200/graylog_0_reindex settings:='{"number_of_shards":4,"number_of_replicas":0}'
+
+Check mapping and index settings
+""""""""""""""""""""""""""""""""
+
+Use these commands to check if the settings and index mapping for the new index are correct.::
+
+    http :9200/graylog_0_reindex/_mapping
+    http :9200/graylog_0_reindex/_settings
+
+Start re-index process
+""""""""""""""""""""""
+This command starts the actual re-index process. It will return a task ID that can be used to check the progress of the re-index task in Elasticsearch.
+
+The size value in the payload is the batch size that will be used for the re-index process. It defaults to 1000 and can be adjusted to tune the re-indexing process.::
+
+    http post :9200/_reindex wait_for_completion==false source:='{"index":"graylog_0","size": 1000}' dest:='{"index":"graylog_0_reindex"}'
+
+The re-index API supports the requests_per_second URL parameter to throttle the re-index process. This can be useful to make sure that the re-index process doesn't take too much resources. See this document for an explanation on how the parameter works: https://www.elastic.co/guide/en/elasticsearch/reference/6.0/docs-reindex.html#_url_parameters_3::
+
+    http post :9200/_reindex wait_for_completion==false requests_per_second==500 source:='{"index":"graylog_0","size": 1000}' dest:='{"index":"graylog_0_reindex"}'
+
+Wait for the re-index to complete and check re-index progress
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+The re-index progress can be checked with the following command using the task ID that has been returned by the re-index request.::
+
+    http :9200/_tasks/<task-id>
+
+Compare documents in the old and new index
+""""""""""""""""""""""""""""""""""""""""""
+
+Before we continue, we should check that all documents have been re-indexed into the new index by comparing the document counts.::
+
+    http :9200/graylog_0/_count
+    http :9200/graylog_0_reindex/_count
+
+Delete old index
+""""""""""""""""
+
+Now delete the old index so we can recreate it for re-indexing.::
+
+    http delete :9200/graylog_0
+
+Recreate old index
+""""""""""""""""""
+
+Recreate the old index again so we can use it as a re-index target. The request needs to include the correct settings for the number of shards and replicas. These settings can be different for each index set! (actual settings can be found in the Graylog "System / Indices" page for each index set)::
+
+    http put :9200/graylog_0 settings:='{"number_of_shards":4,"number_of_replicas":0}'
+
+Check mapping and index settings
+""""""""""""""""""""""""""""""""
+
+Use these commands to check if the settings and index mapping for the recreated index are correct.::
+
+    http :9200/graylog_0/_mapping
+    http :9200/graylog_0/_settings
+
+Start re-index process for old index
+""""""""""""""""""""""""""""""""""""
+
+This command starts the re-index process to move back the documents into the old index. It will return a task ID that can be used to check the progress of the re-index task in Elasticsearch.
+
+The size value in the payload is the batch size that will be used for the re-index process. It defaults to 1000 and can be adjusted to tune the re-indexing process.::
+
+    http post :9200/_reindex wait_for_completion==false source:='{"index":"graylog_0_reindex","size": 1000}' dest:='{"index":"graylog_0"}'
+
+The re-index API supports the requests_per_second URL parameter to throttle the re-index process. This can be useful to make sure that the re-index process doesn't take too much resources. See this document for an explanation on how the parameter works: https://www.elastic.co/guide/en/elasticsearch/reference/6.0/docs-reindex.html#_url_parameters_3::
+
+    http post :9200/_reindex wait_for_completion==false requests_per_second==500 source:='{"index":"graylog_0_reindex","size": 1000}' dest:='{"index":"graylog_0"}'
+
+Compare documents in the old and new index
+""""""""""""""""""""""""""""""""""""""""""
+
+Before we continue, we should check that all documents have been re-indexed into the re-created old index by comparing the document counts with the temporary index.::
+
+    http :9200/graylog_0/_count
+    http :9200/graylog_0_reindex/_count
+
+Create index range for the recreated index
+""""""""""""""""""""""""""""""""""""""""""
+Graylog needs to know about the recreated index by creating an index range for it.::
+
+    http post :9000/api/system/indices/ranges/graylog_0/rebuild x-requested-by:httpie
+
+Delete temporary re-index target index
+""""""""""""""""""""""""""""""""""""""
+
+The temporary re-index target index can now be deleted because we don't use it anymore.::
+
+    http delete :9200/graylog_0_reindex
+
+
+Cleanup
+^^^^^^^
+
+The re-index process leaves some tasks in Elasticsearch that need to be cleaned up automatically.
+
+Find completed re-index tasks for deletion
+""""""""""""""""""""""""""""""""""""""""""
+
+Execute the following command to get all the tasks we should remove.::
+
+    http :9200/.tasks/_search | jq '[.hits.hits[] | select(._source.task.action == "indices:data/write/reindex" and ._source.completed == true) | {"task_id": ._id, "description": ._source.task.description}]'
+
+Remove completed re-index tasks
+"""""""""""""""""""""""""""""""
+
+Execute the following command for every completed task ID.
+Re-Index Commands::
+
+    http delete :9200/.tasks/task/<task-id>
+
+

--- a/pages/upgrade/elasticsearch-6.rst
+++ b/pages/upgrade/elasticsearch-6.rst
@@ -1,0 +1,29 @@
+.. _es6_reindex:
+
+*********************
+Elasticsearch 6 notes
+*********************
+
+
+Upgrades from Elasticsearch 2.x direct to the latest Elasticsearch 6.x are not supported. Only the upgrade from Elasticsearch 5.x is supported and covered by this document.
+
+At first check if the data in Elasticsearch need to be re-indexed::
+
+    $ http :9200/_settings | \
+     jq '[ path(.[] |select(.settings.index.version.created < "5000000"))[] ]'
+
+The above example use the tools `httpie <https://httpie.org/>`__ and `jq <https://stedolan.github.io/jq/>`__ to query the Elasticsearch API and check if any indices are created with Elasticsearch prior to Version 5. If that returns any index names, you need to re-index your data to make them work with Elasticseach 6.
+
+Upgrading to Elasticsearch 6 is always a `full-cluster-restart <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/restart-upgrade.html>`__ and all breaking changes need to checked carefully. Once started their is no going back or downgrade possible.
+
+The `Elasticsearch breaking changes notes <https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.0.html>`__ contain a complete list of changes in Elasticsearch that should be checked against your configuration. The most notable is the cluster name is no longer allowed in `path.data` (see `breaking changes in Elasticsearch 6 <https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-6.0.html#_cluster_name_no_longer_allowed_in_path_data>`__) and the release of `Elasticseach OSS Packages <https://www.elastic.co/products/x-pack/open>`__. 
+
+Upgrade without re-index
+========================
+
+When no re-index is needed the easiest way is to follow the `elastic upgrade guide for Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/6.5/restart-upgrade.html>`__ this gives all needed commands. 
+
+Upgrade wiht re-index
+=====================
+
+ 


### PR DESCRIPTION
This includes the re-index guide, the step-by-step guides now use OSS Packages from Elasticsearch, Docker also refer only to the OSS images.

FIX: https://github.com/Graylog2/documentation/issues/532
FIX: https://github.com/Graylog2/documentation/issues/528