### PR TITLE
updated guides and versions

### DIFF
--- a/pages/installation/operating_system_packages.rst
+++ b/pages/installation/operating_system_packages.rst
@@ -11,7 +11,7 @@ and configuring new software a matter of a single command and a few minutes of t
 
 Graylog offers official ``DEB`` and ``RPM`` package repositories. The packages have been tested on the following operating systems:
 
-* Ubuntu 12.04, 14.04, 16.04
+* Ubuntu 12.04, 14.04, 16.04, 18.04
 * Debian 7, 8, 9
 * RHEL/CentOS 6, 7
 
@@ -25,7 +25,7 @@ Make sure to install and configure the following software before installing and 
 
 * Java (>= 8)
 * MongoDB (>= 2.4)
-* Elasticsearch (>= 2.x)
+* Elasticsearch (>= 5.x)
 
 .. _operating_package_DEB-APT:
 
@@ -43,23 +43,25 @@ via ``dpkg(1)`` and also make sure that the ``apt-transport-https`` package is i
 
 After the installation completed successfully, Graylog can be started with the following commands. Make sure to use the correct command for your operating system.
 
-====================== =========== =======================================
-OS                     Init System Command
-====================== =========== =======================================
-Ubuntu 14.04, 12.04    upstart     ``sudo start graylog-server``
-Debian 7               SysV        ``sudo service graylog-server start``
-Debian 8, Ubuntu 16.04 systemd     ``sudo systemctl start graylog-server``
-====================== =========== =======================================
+
+================================= =========== =======================================
+OS                                Init System Command
+================================= =========== =======================================
+Ubuntu 14.04, 12.04               upstart     ``sudo start graylog-server``
+Debian 7                          SysV        ``sudo service graylog-server start``
+Debian 8 & 9, Ubuntu 16.04, 18.04 systemd     ``sudo systemctl start graylog-server``
+================================= =========== =======================================
+
 
 The packages are configured to **not** start any Graylog services during boot. You can use the following commands to start Graylog when the operating system is booting.
 
-====================== =========== ==================================================
-OS                     Init System Command
-====================== =========== ==================================================
-Ubuntu 14.04, 12.04    upstart     ``sudo rm -f /etc/init/graylog-server.override``
-Debian 7               SysV        ``sudo update-rc.d graylog-server defaults 95 10``
-Debian 8, Ubuntu 16.06 systemd     ``sudo systemctl enable graylog-server``
-====================== =========== ==================================================
+================================= =========== ==================================================
+OS                                Init System Command
+================================= =========== ==================================================
+Ubuntu 14.04, 12.04               upstart     ``sudo rm -f /etc/init/graylog-server.override``
+Debian 7                          SysV        ``sudo update-rc.d graylog-server defaults 95 10``
+Debian 8 & 9, Ubuntu 16.06, 18.04 systemd     ``sudo systemctl enable graylog-server``
+================================= =========== ==================================================
 
 .. _operating_package_upgrade_DEB-APT:
 

--- a/pages/installation/os/centos.rst
+++ b/pages/installation/os/centos.rst
@@ -22,12 +22,13 @@ MongoDB
 
 Installing MongoDB on CentOS should follow `the tutorial for RHEL and CentOS <https://docs.mongodb.com/master/tutorial/install-mongodb-on-red-hat>`_ from the MongoDB documentation. First add the repository file ``/etc/yum.repos.d/mongodb-org-3.6.repo`` with the following contents::
 
-  [mongodb-org-3.6]
+  [mongodb-org-4.0]
   name=MongoDB Repository
-  baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/3.6/x86_64/
+  baseurl=https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/4.0/x86_64/
   gpgcheck=1
   enabled=1
-  gpgkey=https://www.mongodb.org/static/pgp/server-3.6.asc
+  gpgkey=https://www.mongodb.org/static/pgp/server-4.0.asc
+
 
 After that, install the latest release of MongoDB with ``sudo yum install -y mongodb-org``.
 
@@ -55,11 +56,12 @@ First install the Elastic GPG key with ``rpm --import https://artifacts.elastic.
     autorefresh=1
     type=rpm-md
 
-followed by the installation of the latest release with ``sudo yum install elasticsearch``.
+followed by the installation of the latest release with ``sudo yum install elasticsearch-oss``.
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line, and add ``action.auto_create_index: false`` to the configuration file::
 
     cluster.name: graylog
+    action.auto_create_index: false
 
 After you have modified the configuration, you can start Elasticsearch::
 

--- a/pages/installation/os/debian.rst
+++ b/pages/installation/os/debian.rst
@@ -21,8 +21,8 @@ MongoDB
 
 The official MongoDB repository provides the most up-to-date version and is the recommended way of installing MongoDB for Graylog::
 
-  $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-  $ echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/3.6 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+  $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+  $ echo "deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
   $ sudo apt-get update 
   $ sudo apt-get install -y mongodb-org
 
@@ -42,12 +42,13 @@ Graylog 2.5.x should be used with Elasticsearch 6.x, please follow the installat
 
     $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
     $ echo "deb https://artifacts.elastic.co/packages/oss-6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
-    $ sudo apt update && sudo apt install elasticsearch
+    $ sudo apt update && sudo apt install elasticsearch-oss
 
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line, and add ``action.auto_create_index: false`` to the configuration file::
 
     cluster.name: graylog
+    action.auto_create_index: false
 
 After you have modified the configuration, you can start Elasticsearch::
 

--- a/pages/installation/os/sles.rst
+++ b/pages/installation/os/sles.rst
@@ -27,8 +27,8 @@ MongoDB
 
 Installing MongoDB on SLES should follow `the tutorial for SLES <https://docs.mongodb.com/v3.4/tutorial/install-mongodb-on-suse/>`_ from the MongoDB documentation. Add the GPG key and the repository before installing MongoDB::
 
-  $ sudo rpm --import https://www.mongodb.org/static/pgp/server-3.6.asc
-  $ sudo zypper addrepo --gpgcheck "https://repo.mongodb.org/zypper/suse/12/mongodb-org/3.6/x86_64/" mongodb
+  $ sudo rpm --import https://www.mongodb.org/static/pgp/server-4.0.asc
+  $ sudo zypper addrepo --gpgcheck "https://repo.mongodb.org/zypper/suse/12/mongodb-org/4.0/x86_64/" mongodb
   $ sudo zypper -n install mongodb-org
 
 In order to automatically start MongoDB on system boot, you have to activate the MongoDB service by running the following commands::
@@ -53,11 +53,12 @@ First install the Elastic GPG key with ``rpm --import https://artifacts.elastic.
     autorefresh=1
     type=rpm-md
 
-followed by the installation of the latest release with ``sudo zypper install elasticsearch``.
+followed by the installation of the latest release with ``sudo zypper install elasticsearch-oss``.
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line, and add ``action.auto_create_index: false`` to the configuration file::
 
     cluster.name: graylog
+    action.auto_create_index: false
 
 In order to automatically start Elasticsearch on system boot, you have to activate the Elasticsearch service by running the following commands::
 

--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -2,7 +2,7 @@
 Ubuntu installation
 *******************
 
-This guide describes the fastest way to install Graylog on Ubuntu 16.04 LTS. All links and packages are present at the time of writing but might need to be updated later on.
+This guide describes the fastest way to install Graylog on Ubuntu 18.04 LTS. All links and packages are present at the time of writing but might need to be updated later on.
 
 .. warning:: This setup should not be done on publicly exposed servers. This guide **does not cover** security settings!
 
@@ -21,8 +21,8 @@ MongoDB
 
 The official MongoDB repository provides the most up-to-date version and is the recommended way of installing MongoDB for Graylog::
 
-    $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-    $ echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+    $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+    $ echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list    
     $ sudo apt-get update
     $ sudo apt-get install -y mongodb-org
 
@@ -42,11 +42,13 @@ Graylog 2.5.x should be used with Elasticsearch 6.x, please follow the installat
 
     $ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
     $ echo "deb https://artifacts.elastic.co/packages/oss-6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
-    $ sudo apt-get update && sudo apt-get install elasticsearch
+    $ sudo apt-get update && sudo apt-get install elasticsearch-oss
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line::
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line in additon add ``action.auto_create_index: false`` to the configuration file::
 
     cluster.name: graylog
+    action.auto_create_index: false
+
 
 After you have modified the configuration, you can start Elasticsearch::
 

--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -44,7 +44,7 @@ Graylog 2.5.x should be used with Elasticsearch 6.x, please follow the installat
     $ echo "deb https://artifacts.elastic.co/packages/oss-6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
     $ sudo apt-get update && sudo apt-get install elasticsearch-oss
 
-Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line in additon add ``action.auto_create_index: false`` to the configuration file::
+Make sure to modify the `Elasticsearch configuration file <https://www.elastic.co/guide/en/elasticsearch/reference/6.x/settings.html#settings>`__  (``/etc/elasticsearch/elasticsearch.yml``) and set the cluster name to ``graylog`` additionally you need to uncomment (remove the # as first character) the line, and add ``action.auto_create_index: false`` to the configuration file::
 
     cluster.name: graylog
     action.auto_create_index: false


### PR DESCRIPTION
I have updated the Ubuntu Guide after test to 18.04 LTS and checked some versions and commands on the other OS installations.

This needs to be published to 3.0 too