### PR TITLE
Add Enterprise Setup tar download link back

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -359,4 +359,4 @@ epub_exclude_files = ['search.html']
 # If false, no index is generated.
 #epub_use_index = True
 
-extlinks = {'enterprise-plugins-tar': ('https://downloads.graylog.org/releases/graylog-enterprise/plugin-bundle/tgz/graylog-enterprise-plugins-%s.tgz', None)}
+extlinks = {'enterprise-plugins-tar': ( 'https://downloads.graylog.org/releases/graylog-enterprise/graylog-enterprise-plugins-%s.tgz', None)}

--- a/conf.py
+++ b/conf.py
@@ -359,5 +359,4 @@ epub_exclude_files = ['search.html']
 # If false, no index is generated.
 #epub_use_index = True
 
-# See revision history for link format.
-#extlinks = {}
+extlinks = {'enterprise-plugins-tar': ('https://downloads.graylog.org/releases/graylog-enterprise/plugin-bundle/tgz/graylog-enterprise-plugins-%s.tgz', None)}

--- a/conf.py
+++ b/conf.py
@@ -359,4 +359,8 @@ epub_exclude_files = ['search.html']
 # If false, no index is generated.
 #epub_use_index = True
 
-extlinks = {'enterprise-plugins-tar': ( 'https://downloads.graylog.org/releases/graylog-enterprise/graylog-enterprise-plugins-%s.tgz', None)}
+extlinks = {
+    'enterprise-plugins-tar': ( 'https://downloads.graylog.org/releases/graylog-enterprise/graylog-enterprise-plugins-%s.tgz', None),
+    'enterprise-integrations-plugins-tar': ( 'https://downloads.graylog.org/releases/graylog-integrations/graylog-integrations-plugins-%s.tgz', None),
+    'integrations-plugins-tar': ( 'https://downloads.graylog.org/releases/graylog-enterprise-integrations/graylog-enterprise-integrations-plugins-%s.tgz', None)
+}

--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -102,7 +102,15 @@ The installation on distributions like CentOS or RedHat can be done with *yum* a
 Tarball
 -------
 
-If you have done a manual installation you can get the tarball from the `Graylog Downloads <https://www.graylog.org/downloads>`_ page.
+If you have done a manual installation you can get the tarball from the download locations listed in the following table.
+
+.. list-table:: Enterprise Plugins download
+    :header-rows: 1
+
+    * - Enterprise Version
+      - Download URL
+    * - 3.0.0
+      - :enterprise-plugins-tar:`3.0.0`
 
 The tarball includes the enterprise plugin JAR file and required binaries that need to be installed.
 

--- a/pages/integrations.rst
+++ b/pages/integrations.rst
@@ -11,6 +11,8 @@ Integrations
 
 Integrations are tools that help Graylog work with external systems. Integrations will typically be content packs, inputs, or lookup tables and can either be open source or Enterprise.
 
+Reference the :doc:`Integrations Setup <integrations/setup>` document for installation instructions.
+
 Below are the available features:
 
 
@@ -31,7 +33,5 @@ Enterprise Integrations plugin feature require an `Graylog Enterprise license <h
 For a comprehensive list of available features included, see our  :ref:`Enterprise List page<enterprise_features>`
 
 * :ref:`Script Alert Notification<alerts_script_alert>`
-
-Please reference the :doc:`Integrations Setup <integrations/setup>` document for installation instructions.
 
 Also see the :doc:`Change Log <integrations/changelog>`.

--- a/pages/integrations/setup.rst
+++ b/pages/integrations/setup.rst
@@ -41,12 +41,13 @@ The installation on distributions like CentOS or RedHat can be done with *yum* a
 
   $ sudo yum install graylog-integrations-plugins graylog-enterprise-integrations-plugins
 
+Tarballs
+^^^^^^^^
 
-Jar File
-~~~~~~~~
+If you have done a manual installation, you download the tarballs from the following links.
 
-You can also download the JAR plugin files from the `Graylog Downloads <https://www.graylog.org/downloads>`_ page.
-
+* :enterprise-integrations-plugins-tar:`3.0.0`
+* :integrations-plugins-tar:`3.0.0`
 
 Server Restart
 ==============


### PR DESCRIPTION
Add Enterprise Setup tar download link back since a centralized Downloads page will not be ready for a while.

Reverts commit 66aeffe80b661b298141a951373a6ba8df5e6357