### PR TITLE
Update enterprise documentation

### DIFF
--- a/pages/archiving.rst
+++ b/pages/archiving.rst
@@ -20,7 +20,7 @@ even print them out if you need to! If you need to search through archived data 
 selection of archived messages back into the Graylog archive folder, and the web interface will enable
 you to temporarily import the archive so you can analyze the messages again in Graylog.
 
-.. note:: The archive plugin is a commercial feature and part of `Graylog Enterprise <https://www.graylog.org/enterprise>`_.
+.. note:: Archiving is a commercial feature and part of `Graylog Enterprise <https://www.graylog.org/enterprise>`_.
 
 .. toctree::
    :titlesonly:

--- a/pages/archiving/setup.rst
+++ b/pages/archiving/setup.rst
@@ -2,19 +2,20 @@
 Setup
 *****
 
-The archive plugin is a commercial Graylog feature that can be installed in
-addition to the Graylog open source server.
+Graylog Archive is a commercial feature that can be installed in addition to
+the Graylog open source server.
 
 Installation
 ============
 
-Please see the :doc:`Graylog Enterprise setup page </pages/enterprise/setup>` for details on how to install
-the Archive plugin.
+Archiving is part of the Graylog Enterprise plugin, please check the
+:doc:`Graylog Enterprise setup page </pages/enterprise/setup>` for details on
+how to install it.
 
 Configuration
 =============
 
-The archive plugin can be configured via the Graylog web interface and does
+Graylog Archive can be configured via the Graylog web interface and does
 not need any changes in the Graylog server configuration file.
 
 In the web interface menu navigate to "System/Archives" and click "Configuration"
@@ -25,7 +26,7 @@ to adjust the configuration.
 Archive Options
 ---------------
 
-There are several configuration options to configure the archive plugin.
+There are several configuration options to configure archiving.
 
 .. list-table:: Configuration Options
     :header-rows: 1
@@ -238,8 +239,8 @@ Graylog is using configurable index retention strategies to delete old
 indices. By default indices can be *closed* or *deleted* if you have more
 than the configured limit.
 
-The archive plugin offers a new index retention strategy that you can configure
-to automatically archive an index before closing or deleting it.
+Graylog Archive offers a new index retention strategy that you can configure to
+automatically archive an index before closing or deleting it.
 
 Index retention strategies can be configured in the system menu under
 "System/Indices". Select an index set and click "Edit" to change the index rotation

--- a/pages/archiving/setup.rst
+++ b/pages/archiving/setup.rst
@@ -18,7 +18,7 @@ Configuration
 Graylog Archive can be configured via the Graylog web interface and does
 not need any changes in the Graylog server configuration file.
 
-In the web interface menu navigate to "System/Archives" and click "Configuration"
+In the web interface menu navigate to "Enterprise/Archives" and click "Configuration"
 to adjust the configuration.
 
 .. image:: /images/archiving-setup-config.png

--- a/pages/archiving/usage.rst
+++ b/pages/archiving/usage.rst
@@ -17,7 +17,7 @@ indices.
 Web Interface
 -------------
 
-You can manually create an archive on the "System/Archives" page in the
+You can manually create an archive on the "Enterprise/Archives" page in the
 web interface.
 
 .. image:: /images/archiving-usage-create-web.png
@@ -119,7 +119,7 @@ anymore.
 Web Interface
 -------------
 
-In the web interface you can restore an archive on the "System/Archives" page
+In the web interface you can restore an archive on the "Enterprise/Archives" page
 by selecting an archive from the list, open the archive details and clicking
 the "Restore Index" button.
 

--- a/pages/archiving/usage.rst
+++ b/pages/archiving/usage.rst
@@ -34,7 +34,7 @@ changing your :ref:`index retention configuration <archive-config-index-retentio
 Index Retention
 ---------------
 
-The archive plugin ships with an index retention strategy that can be used
+Graylog Archive ships with an index retention strategy that can be used
 to automatically create archives before closing or deleting Elasticsearch
 indices.
 
@@ -49,7 +49,7 @@ on how to configure it.
 REST API
 --------
 
-The archive plugin also offers a REST API that you can use to automate archive
+Graylog Archive also offers a REST API that you can use to automate archive
 creation if you have some special requirements and need a more flexible way to
 do this.
 
@@ -99,12 +99,12 @@ Restoring Archives
           behaves. Also use the :ref:`Restore Index Batch Size <archive-config-option-restore-batch-size>`
           setting to control the Elasticsearch batch size on re-index.
 
-The archive plugin offer two ways to restore archived indices.
+Graylog Archive offers two ways to restore archived indices.
 
 * :ref:`Web Interface <archive-restore-web-interface>`
 * :ref:`REST API <archive-restore-rest-api>`
 
-The archive plugin restores all indices into the "Restored Archives" index set
+Graylog Archive restores all indices into the "Restored Archives" index set
 to avoid conflicts with the original indices. (should those still exist)
 
 .. image:: /images/archiving-usage-restore-web-result.png

--- a/pages/auditlog.rst
+++ b/pages/auditlog.rst
@@ -4,12 +4,12 @@
 Audit Log
 *********
 
-The Audit Log plugin keeps track of changes made by users to a Graylog system.
+Audit Log keeps track of changes made by users to a Graylog system.
 
 It records all state changes into the database and makes it possible to search,
 filter and export all audit log entries.
 
-.. note:: The audit log plugin is a commercial feature and part of `Graylog Enterprise <https://www.graylog.org/enterprise>`_.
+.. note:: Audit Log is a commercial feature and part of `Graylog Enterprise <https://www.graylog.org/enterprise>`_.
 
 .. toctree::
    :titlesonly:

--- a/pages/auditlog/setup.rst
+++ b/pages/auditlog/setup.rst
@@ -2,21 +2,20 @@
 Setup
 *****
 
-The Audit Log plugin is a commercial Graylog feature that can be installed in
+Graylog Audit Log is a commercial feature that can be installed in
 addition to the Graylog open source server.
 
 Installation
 ============
 
-Please see the :ref:`Graylog Enterprise setup page <enterprise-setup>` for details on how to install
-the Audit Log plugin.
-
-.. note:: Make sure the Audit Log plugin is installed on every node in your Graylog cluster.
+Audit Log functionality is part of the Graylog Enterprise plugin, please check
+the :ref:`Graylog Enterprise setup page <enterprise-setup>` for details on how
+to install it.
 
 Configuration
 =============
 
-The audit log plugin provides two ways of writing audit log entries:
+Graylog Audit Log provides two ways of writing audit log entries:
 
 1. Database
 2. Log file via `log4j2 <https://logging.apache.org/log4j/2.x/>`_ appender
@@ -86,8 +85,8 @@ Example::
 auditlog_mongodb_collection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This configures the name of the MongoDB collection where the audit log plugin#
-stores the audit log entries.
+This configures the name of the MongoDB collection where audit log entries will
+be stored.
 
 The default value for this is ``audit_log``.
 
@@ -227,10 +226,10 @@ Caveats
 You have to make sure that the log4j2 related settings in the Graylog server
 config file and the ``log4j2.xml`` file are the same on **every node in your cluster**!
 
-Since every Graylog server writes its own audit log entries when the plugin
-is installed, the log files configured in the ``log4j2.xml`` file are written
-on every node. But **only** the entries from the local node will show up in
-that file.
+Since every Graylog server writes its own audit log entries when the Graylog
+Enterprise plugin is installed, the log files configured in the ``log4j2.xml``
+file are written on every node. But **only** the entries from the local node
+will show up in that file.
 
 If you have more than one node, you have to search in all configured files
 on all nodes to get a complete view of the audit trail.

--- a/pages/auditlog/usage.rst
+++ b/pages/auditlog/usage.rst
@@ -2,13 +2,13 @@
 Usage
 *****
 
-Once you installed the Audit Log plugin, Graylog will automatically write
+Once you installed the Graylog Enterprise plugin, Graylog will automatically write
 audit log entries into the database.
 
 View Audit Log Entries
 ======================
 
-The plugin adds a new page to the web interface which can be reached via
+Graylog Audit Log adds a new page to the web interface which can be reached via
 "System/Audit Log". You can view and export existing audit log entries in
 the database.
 

--- a/pages/auditlog/usage.rst
+++ b/pages/auditlog/usage.rst
@@ -9,7 +9,7 @@ View Audit Log Entries
 ======================
 
 Graylog Audit Log adds a new page to the web interface which can be reached via
-"System/Audit Log". You can view and export existing audit log entries in
+"Enterprise/Audit Log". You can view and export existing audit log entries in
 the database.
 
 It also provides a simple search form to search and filter for audit events

--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -4,8 +4,8 @@
 Setup
 *****
 
-Graylog Enterprise comes as a set of Graylog server plugins which need to be
-installed in addition to the Graylog open source setup.
+Graylog Enterprise comes as a Graylog server plugin which need to be installed
+in addition to the Graylog open source setup.
 
 Requirements
 ============
@@ -60,22 +60,22 @@ The following list shows the minimum required Graylog versions for the Graylog E
 Installation
 ============
 
-Since Graylog 2.4 the Graylog Enterprise plugins can be installed the same way Graylog is installed. In most setups this will be done with the package tool provided by the distribution you are using and the online repository.
+Since Graylog 2.4 the Graylog Enterprise plugin can be installed the same way Graylog is installed. In most setups this will be done with the package tool provided by the distribution you are using and the online repository.
 
 .. note:: For previous versions of Graylog Enterprise please contact your Graylog account manager.
 
-Once you installed the Graylog Enterprise plugins you need to obtain a license from `the Graylog Enterprise web page <https://www.graylog.org/enterprise/>`_.
+Once you installed the Graylog Enterprise plugin you need to obtain a license from `the Graylog Enterprise web page <https://www.graylog.org/enterprise/>`_.
 
 Should a simple `apt-get install graylog-enterprise-plugins` or `yum install graylog-enterprise-plugins` not work for you, the following information might help you.
 
-.. important:: The Graylog Enterprise plugins need to be installed on all your Graylog nodes!
+.. important:: The Graylog Enterprise plugin need to be installed on all your Graylog nodes!
 
 DEB / RPM Package
 -----------------
 
 The default installation should be done with the system package tools. It includes the repository installation that is described in the :doc:`/pages/installation/operating_system_packages` installation guides.
 
-When the usage of online repositorys is not possible in your environment, you can download the Graylog Enterprise plugins at `https://packages.graylog2.org <https://packages.graylog2.org>`_.
+When the usage of online repositories is not possible in your environment, you can download the Graylog Enterprise plugins at `https://packages.graylog2.org <https://packages.graylog2.org>`_.
 
 .. note:: These packages can **only** be used when you installed Graylog via the :doc:`/pages/installation/operating_system_packages`!
 
@@ -102,19 +102,23 @@ The installation on distributions like CentOS or RedHat can be done with *yum* a
 Tarball
 -------
 
-If you have done a manual installation or want to include only parts of the enterprise plugins you can get the tarball from the `Graylog Downloads <https://www.graylog.org/downloads>`_ page.
+If you have done a manual installation you can get the tarball from the `Graylog Downloads <https://www.graylog.org/downloads>`_ page.
 
-The tarball includes the enterprise plugin JAR files.
+The tarball includes the enterprise plugin JAR file and required binaries that need to be installed.
 
 ::
 
   $ tar -tzf graylog-enterprise-plugins-3.0.0.tgz
     graylog-enterprise-plugins-3.0.0/LICENSE
-    graylog-enterprise-plugins-3.0.0/plugin/graylog-plugin-archive-3.0.0.jar
-    graylog-enterprise-plugins-3.0.0/plugin/graylog-plugin-auditlog-3.0.0.jar
-    graylog-enterprise-plugins-3.0.0/plugin/graylog-plugin-license-3.0.0.jar
+    graylog-enterprise-plugins-3.0.0/plugin/graylog-plugin-enterprise-3.0.0.jar
+    graylog-enterprise-plugins-3.0.0/bin/headless_shell
+    graylog-enterprise-plugins-3.0.0/bin/chromedriver
+    graylog-enterprise-plugins-3.0.0/bin/chromedriver_start.sh
 
-Depending on the Graylog setup method you have used, you have to install the plugins into different locations.
+
+**JAR file**
+
+Depending on the Graylog setup method you have used, you have to install the plugin into different locations.
 
 .. include:: /includes/plugin-installation-locations.rst
 
@@ -126,20 +130,14 @@ Your plugin directory should look similar to this after installing the enterpris
 ::
 
   plugin/
-  ├── graylog-plugin-auditlog-3.0.0.jar
-  ├── graylog-plugin-threatintel-3.0.0.jar
-  ├── graylog-plugin-archive-3.0.0.jar
-  ├── graylog-plugin-beats-3.0.0.jar
-  ├── graylog-plugin-netflow-3.0.0.jar
   ├── graylog-plugin-aws-3.0.0.jar
-  ├── graylog-plugin-pipeline-processor-3.0.0.jar
-  ├── graylog-plugin-enterprise-integration-3.0.0.jar
-  ├── graylog-plugin-map-widget-3.0.0.jar
-  ├── graylog-plugin-cef-3.0.0.jar
-  ├── graylog-plugin-license-3.0.0.jar
-  └── graylog-plugin-collector-3.0.0.jar
+  ├── graylog-plugin-collector-3.0.0.jar
+  ├── graylog-plugin-enterprise-3.0.0.jar
+  └── graylog-plugin-threatintel-3.0.0.jar
 
+**Binary files**
 
+Check the ``bin_dir`` configuration option set in your Graylog server configuration file. That is the location where you need to copy the binaries included in the Graylog Enterprise tarball.
 
 Server Restart
 ==============
@@ -154,15 +152,9 @@ You should see something like the following in your Graylog server logs. It indi
 ::
 
   2017-12-18T17:39:10.797+01:00 INFO  [CmdLineTool] Loaded plugin: AWS plugins 3.0.0 [org.graylog.aws.plugin.AWSPlugin]
-  2017-12-18T17:39:10.803+01:00 INFO  [CmdLineTool] Loaded plugin: Audit Log 3.0.0 [org.graylog.plugins.auditlog.AuditLogPlugin]
-  2017-12-18T17:39:10.805+01:00 INFO  [CmdLineTool] Loaded plugin: Elastic Beats Input 3.0.0 [org.graylog.plugins.beats.BeatsInputPlugin]
-  2017-12-18T17:39:10.807+01:00 INFO  [CmdLineTool] Loaded plugin: CEF Input 3.0.0 [org.graylog.plugins.cef.CEFInputPlugin]
   2017-12-18T17:39:10.809+01:00 INFO  [CmdLineTool] Loaded plugin: Collector 3.0.0 [org.graylog.plugins.collector.CollectorPlugin]
   2017-12-18T17:39:10.811+01:00 INFO  [CmdLineTool] Loaded plugin: Enterprise Integration Plugin 3.0.0 [org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin]
-  2017-12-18T17:39:10.812+01:00 INFO  [CmdLineTool] Loaded plugin: License Plugin 3.0.0 [org.graylog.plugins.license.LicensePlugin]
-  2017-12-18T17:39:10.814+01:00 INFO  [CmdLineTool] Loaded plugin: MapWidgetPlugin 3.0.0 [org.graylog.plugins.map.MapWidgetPlugin]
-  2017-12-18T17:39:10.815+01:00 INFO  [CmdLineTool] Loaded plugin: NetFlow Plugin 3.0.0 [org.graylog.plugins.netflow.NetFlowPlugin]
-  2017-12-18T17:39:10.826+01:00 INFO  [CmdLineTool] Loaded plugin: Pipeline Processor Plugin 3.0.0 [org.graylog.plugins.pipelineprocessor.ProcessorPlugin]
+  2017-12-18T17:39:10.805+01:00 INFO  [CmdLineTool] Loaded plugin: Graylog Enterprise 3.0.0 [org.graylog.plugins.enterprise.EnterprisePlugin]
   2017-12-18T17:39:10.827+01:00 INFO  [CmdLineTool] Loaded plugin: Threat Intelligence Plugin 3.0.0 [org.graylog.plugins.threatintel.ThreatIntelPlugin]
 
 Cluster Setup
@@ -196,9 +188,9 @@ The license automatically applies to all nodes in your cluster without the need 
 License Verification
 ====================
 
-Some Graylog licenses require to check their validity on a regular basis. This includes the free Graylog Enterprise license with a specific amount of traffic included. 
+Some Graylog licenses require to check their validity on a regular basis. This includes the free Graylog Enterprise license with a specific amount of traffic included.
 
-If your network environment requires Graylog to use a proxy server in order to communicate with the external services via HTTPS, you'll have to configure the proxy server in the :ref:`Graylog configuration file<http_config>`. 
+If your network environment requires Graylog to use a proxy server in order to communicate with the external services via HTTPS, you'll have to configure the proxy server in the :ref:`Graylog configuration file<http_config>`.
 
 The Graylog web interface shows all details about the license, but if you are still unclear about the requirements, please contact our `sales team <https://www.graylog.org/contact-sales>`_ with your questions.
 
@@ -217,7 +209,7 @@ license:
 * A flag indicating if the license has expired
 * A flag indicating if Graylog detected that the traffic measuring mechanisms have been modified
 * A list of how much traffic was received and written by Graylog in the recent days, in bytes
-  
+
 Details on licensed traffic
 ---------------------------
 

--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -179,7 +179,7 @@ The Graylog Enterprise plugins require a valid license to use the additional fea
 Once you have `obtained a license <https://www.graylog.org/enterprise/>`_
 you can import it into your Graylog setup by going through the following steps.
 
-#. As an admin user, open the System / License page from the menu in the web interface.
+#. As an admin user, open the "Enterprise/License" page from the menu in the web interface.
 #. Click the Import new license button in the top right hand corner.
 #. Copy the license text from the confirmation email and paste it into the text field.
 #. The license should be valid and a preview of your license details should appear below the text field.

--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -137,7 +137,20 @@ Your plugin directory should look similar to this after installing the enterpris
 
 **Binary files**
 
-Check the ``bin_dir`` configuration option set in your Graylog server configuration file. That is the location where you need to copy the binaries included in the Graylog Enterprise tarball.
+Depending on the Graylog setup method you have used, you have to copy the binaries into different locations.
+
+.. list-table:: Binaries Installation Locations
+    :header-rows: 1
+    :widths: 7 20
+
+    * - Installation Method
+      - Directory
+    * - :doc:`/pages/installation/operating_system_packages`
+      - ``/usr/share/graylog-server/bin/``
+    * - :doc:`/pages/installation/manual_setup`
+      - ``/<extracted-graylog-tarball-path>/bin/``
+
+Make sure to check the ``bin_dir`` configuration option set in your Graylog server configuration file, as the default may have changed.
 
 Server Restart
 ==============


### PR DESCRIPTION
This PR updates the documentation for Graylog Enterprise, covering:

- Graylog Enterprise will be shipped as a single plugin.
- Web interface menu changed from System to Enterprise.
- Enterprise tarball also includes binary files that need to be copied in the right location.
