### PR TITLE
Note on Graylog Password Secret (#533)

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -93,7 +93,7 @@ Example::
     graylog:
       image: graylog/graylog:3.0
       environment:
-        # CHANGE ME!
+        # CHANGE ME (must be at least 16 characters)!
         - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
         # Password: admin
         - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
@@ -225,7 +225,7 @@ Using Docker volumes for the data of MongoDB, Elasticsearch, and Graylog, the ``
       volumes:
         - graylog_journal:/usr/share/graylog/data/journal
       environment:
-        # CHANGE ME!
+        # CHANGE ME (must be at least 16 characters)!
         - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
         # Password: admin
         - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918


### PR DESCRIPTION
Added a comment in the docker-compose file regarding the GRAYLOG_PASSWORD_SECRET.

The minimum length is 16 characters.

(cherry picked from commit 2fa2b266e931ae3bc8906571ed63b6b6778c139b)