### PR TITLE
Update geolocation documentation

### DIFF
--- a/pages/geolocation.rst
+++ b/pages/geolocation.rst
@@ -5,102 +5,78 @@ Geolocation
 ***********
 
 Graylog lets you extract and visualize geolocation information from IP addresses in your logs.
-Here we will explain how to install and configure the geolocation resolution, and how to create a
+Here we will explain how to configure the geolocation resolution, and how to create a
 map with the extracted geo-information.
-
-Setup
-=====
-The `Graylog Map Widget <https://github.com/Graylog2/graylog-plugin-map-widget>`_ is the plugin
-providing geolocation capabilities to Graylog. The plugin is compatible with Graylog 2.0.0 and
-higher, and it is installed by default, although **some configuration is still required on your
-side**. This section explains how to configure the plugin in detail.
-
-In case you need to reinstall the plugin for some reason, you can find it inside the Graylog
-tarball in our `downloads page <https://www.graylog.org/download/>`_. Follow the instructions in
-:ref:`installing_and_loading_plugins` to install it.
-
 
 .. _configure_geolocation:
 
-Configure the database
+Setup
+=====
+Graylog ships with geolocation capabilities by default but **some configuration is still required on your
+side**. This section explains how to configure the functionality in detail.
+
+
+On Graylog 3.0, the preferred way of configuring geolocation is by using
+:doc:`Lookup Tables </pages/lookuptables>`, as it provides more flexibility
+and is compatible with more database types. If you would rather use the old
+Message Processor, please check the
+`2.5 documentation </en/2.5/pages/geolocation.html#configure-the-database>`_.
+
+.. note:: Before you get started, we recommend taking a look at some Lookup
+   Table concepts in :ref:`the documentation <lookuptables>`.
+
+
+Download the database
+---------------------
+
+In first place, you need to download a geolocation database. The Lookup Table
+Geo IP Data Adapter supports both **MaxMind City and Country databases** in
+the **MaxMind DB format**, as the
+`GeoIP2 Databases <https://www.maxmind.com/en/geoip2-databases>`_ or
+`GeoLite2 Databases <https://dev.maxmind.com/geoip/geoip2/geolite2/>`_ that MaxMind provides.
+
+The next step is to store the geolocation database in all servers running
+Graylog. Make sure you grant the right permissions to the file so the user
+running Graylog can read the database.
+
+
+Configure Lookup Table
 ----------------------
 
-In first place, you need to download a geolocation database. We currently support **MaxMind City
-databases** in the **MaxMind DB format**, as the
-`GeoIP2 City Database <https://www.maxmind.com/en/geoip2-city>`_ or
-`GeoLite2 City Database <https://dev.maxmind.com/geoip/geoip2/geolite2/>`_ that MaxMind provides.
+The next step is to configure a Graylog Lookup Table that is able to use the
+geolocation database. Follow the
+:ref:`Lookup Tables setup documentation <lookuptables_setup>` to see what you
+need to do. In most common cases you need to:
 
-The next step is to store the geolocation database in all servers running Graylog. As an example, if you
-were using the Graylog OVA, you could save the database in the ``/var/opt/graylog/data`` folder, along
-with other data used by Graylog. Make sure you grant the right permissions so the user running Graylog
-can read the file.
-
-Then you need to configure Graylog to start using the geolocation database to resolve IPs in your logs.
-To do that, open Graylog web interface in your favourite browser, and go to *System -> Configurations*.
-You can find the geolocation configuration under the *Plugins / Geo-Location Processor* section, as seen
-in the screenshot.
-
-.. image:: /images/geolocation_1.png
-
-In the configuration modal, you need to check the `Enable geolocation processor`, and enter the path to
-the geolocation database you use. Once you are all set, click on save to store the configuration changes.
-
-.. image:: /images/geolocation_2.png
+#. Create a Geo IP Data Adapter and point it to the location where you store
+   the database. You can additionally test the Data Adapter to ensure it all
+   works as expected.
+#. Create a Cache (if needed) to make your lookups faster.
+#. Create a Lookup Table that uses the Data Adapter and Cache you created in
+   previous steps.
 
 
-.. _configure_message_processor:
+Use the Lookup Table
+--------------------
 
-Configure the message processor
--------------------------------
+Now you are almost ready to extract geolocation information from IP addresses.
+All you need to do is to use the Lookup Table you created in the previous step
+in a Extractor, Converter, Decorator or Pipeline Rule. Take a look at the
+:ref:`Lookup Tables usage documentation <lookuptables_usage>` for more information.
 
-The last step before being able to resolve locations from IPs in your logs, is to activate the GeoIP Resolver
-processor. In the same *System -> Configurations* page, update the configuration in the *Message Processors
-Configuration* section.
-
-.. image:: /images/geolocation_3.png
-
-In that screen, you need to **enable the GeoIP Resolver**, and you must also **set the GeoIP Resolver as
-the last message processor to run**, if you want to be able to resolve geolocation from fields coming from
-extractors.
-
-.. image:: /images/geolocation_4.png
-
-
-That's it, at this point Graylog will start looking for fields **containing exclusively** an IPv4 or IPv6
-address, and extracting their geolocation into a ``<field>_geolocation`` field.
-
-.. note:: In case you are not sending structured logs to Graylog, you can use extractors to store the IP addresses in your messages into their own fields. Check out the :ref:`extractors` documentation for more information.
-
-.. important:: The GeoIP Resolver processor will **not process** any internal message fields, i. e. any field starting with ``gl2_`` such as ``gl2_remote_ip``.
-
-
-Verify the geolocation configuration (Optional)
------------------------------------------------
-
-To ensure the geolocation resolution is working as expected, you can do the following:
-
-1. Create a TCP Raw/Plaintext input:
-
-.. image:: /images/geolocation_5.png
-
-2. Send a message only containing an IP to the newly created input. As an example, we will be using the `nc` command:
-``nc -w0 <graylog_host> 5555 <<< '8.8.8.8'``
-
-3. Verify that the message contains a ``message_geolocation`` field:
-
-.. image:: /images/geolocation_6.png
-
-4. Delete the input if you don't need it any more
-
-In case the message does not contain a ``message_geolocation`` field, please check your Graylog server logs, and
-ensure you followed the steps in the :ref:`configure_geolocation` section.
+.. note:: Make sure to read :ref:`message_processor_ordering`, specially if
+   you will use the Lookup Table with a Pipeline, in order to better understand
+   how Graylog will process messages.
 
 
 Visualize geolocations in a map
 ===============================
 
 Graylog can display maps from geolocation stored in any field, as long as the geo-points are using the
-``latitude,longitude`` format.
+``latitude,longitude`` format. The default return value of the Geo IP Data Adapter
+returns the coordinates in the right format, so you most likely don't need to do
+anything special if you are using a Lookup Table for extracting geolocation
+information.
 
 
 Display a map in the search results page
@@ -127,32 +103,34 @@ FAQs
 
 Will Graylog extract IPs from all fields?
 -----------------------------------------
-Yes, as long as they contain exclusively an IP address.
+No, you can configure which fields you want to extract data from in the Pipeline
+Rule or Extractor using the Lookup Table configured in the :ref:`setup section <configure_geolocation>`.
 
 What geo-information is extracted from IPs?
 -------------------------------------------
-Since version 2.2.0, Graylog extracts the IP coordinates, country ISO code, and the city name if available.
+Depending on the database you use, the extracted information will be different.
+By using a Pipeline Rule alongside a Lookup Table, you can extract any information
+returned by the MaxMind Database for the IP in your logs.
 
 Where is the extracted geo-information stored?
 ----------------------------------------------
-Extracted geo-information is stored in new message fields, named as the original field, and appended suffix
-describing the stored information. That is, if the original field was called ``ip_address``, the extracted
-geo-information will be stored as follows:
+Extracted geo-information is stored in message fields, which you can name as
+you wish.
 
-- ``ip_address_geolocation`` will contain the geo-coordinates
-- ``ip_address_country_code`` will contain the country ISO code
-- ``ip_address_city_name`` will contain the city name (if available) or ``N/A`` in other case
+Which geo-points format does Graylog use to store coordinates?
+--------------------------------------------------------------
+Graylog returns the geolocation information in the ``latitude,longitude`` format.
+The Map visualization also requires that format to be able to draw the coordinates
+on a map.
 
-Which geo-points format does Graylog use to store geolocation information?
---------------------------------------------------------------------------
-Graylog stores the geolocation information in the ``latitude,longitude`` format.
-
-I have a field in my messages with geolocation information already, can I use it in Graylog?
+I have a field in my messages with coordinates information already, can I use it in Graylog?
 --------------------------------------------------------------------------------------------
-Yes, as long as it contains geolocation information in the ``latitude,longitude`` format.
+Yes, you can display a map for coordinates as long as they are in the
+``latitude,longitude`` format.
 
 Not all fields containing IP addresses are resolved. Why does this happen?
 --------------------------------------------------------------------------
-Most likely it is a misconfiguration issue. Please ensure that **the IPs you want to get geolocation
-information from are in their own fields**, and also ensure that **the GeoIP Resolver is enabled, and in the
-right order** in the *Message Processors Configuration*, as explained in :ref:`configure_message_processor`.
+Most likely it is a misconfiguration issue. It is easier to extract information
+if **IP addresses are in their own field**. You should also make sure your
+**Message Processors are in the right order** in the *Message Processors
+Configuration*, as explained in :ref:`message_processor_ordering`.

--- a/pages/geolocation.rst
+++ b/pages/geolocation.rst
@@ -29,13 +29,13 @@ Message Processor, please check the
 Download the database
 ---------------------
 
-In first place, you need to download a geolocation database. The Lookup Table
+In the first place, you need to download a geolocation database. The Lookup Table
 Geo IP Data Adapter supports both **MaxMind City and Country databases** in
 the **MaxMind DB format**, as the
 `GeoIP2 Databases <https://www.maxmind.com/en/geoip2-databases>`_ or
 `GeoLite2 Databases <https://dev.maxmind.com/geoip/geoip2/geolite2/>`_ that MaxMind provides.
 
-The next step is to store the geolocation database in all servers running
+The next step is to store the geolocation database on all servers running
 Graylog. Make sure you grant the right permissions to the file so the user
 running Graylog can read the database.
 

--- a/pages/lookuptables.rst
+++ b/pages/lookuptables.rst
@@ -81,6 +81,8 @@ and a multi value.
 
 .. image:: /images/lookuptables/example-multi-value.png
 
+.. _lookuptables_setup:
+
 Setup
 -----
 
@@ -131,6 +133,8 @@ be used if a lookup operation does not return any result.
 
 .. image:: /images/lookuptables/setup-table-defaults.png
 
+
+.. _lookuptables_usage:
 
 Usage
 -----

--- a/pages/lookuptables.rst
+++ b/pages/lookuptables.rst
@@ -185,7 +185,7 @@ on the Add/Edit Data Adapter page in Graylog.
 CSV File Adapter
 ^^^^^^^^^^^^^^^^
 
-Preforms key/value lookups from a CSV file.
+Performs key/value lookups from a CSV file.
 
 DNS Lookup Adapter
 ^^^^^^^^^^^^^^^^^^
@@ -208,3 +208,10 @@ HTTP JSONPath Adapter
 ^^^^^^^^^^^^^^^^^^^^^
 
 Executes HTTP GET requests to lookup a key and parses the result based on configured JSONPath expressions.
+
+Geo IP - MaxMind Databases
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Provides the ability to extract geolocation information of IP addresses
+from MaxMind Country and City databases.
+

--- a/pages/pipelines/stream_connections.rst
+++ b/pages/pipelines/stream_connections.rst
@@ -26,6 +26,8 @@ However, if you prefer to use the original stream matching functionality (i.e. s
 *Message Filter Chain* (in the *Message Processors Configuration* section of the *System -> Configurations* page) and connect pipelines to existing streams.
 This gives you fine-grained control over the extraction, conversion, and enrichment process.
 
+.. _message_processor_ordering:
+
 The importance of message processor ordering
 ============================================
 It's important to note that the order of message processors may have a significant impact on how your messages get processed.


### PR DESCRIPTION
Update geolocation documentation to:

- Include Geo IP data adapter.
- Remove references to Map plugin.
- Update setup guide, as using a Lookup Table is now considered to be the way to go to get geolocation from your messages (we still provide the old Message processor, though).
