### PR TITLE
Update docker.rst

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -27,7 +27,7 @@ If you simply want to checkout Graylog without any further customization, you ca
       -d docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.4
   $ docker run --link mongo --link elasticsearch \
       -p 9000:9000 -p 12201:12201 -p 514:514 \
-      -e GRAYLOG_HTTP_BIND_ADDRESS="http://127.0.0.1:9000/api" \
+      -e GRAYLOG_HTTP_BIND_ADDRESS="127.0.0.1:9000" \
       -d graylog/graylog:3.0
 
 How to get log data in
@@ -39,7 +39,7 @@ For example, to start a Raw/Plaintext TCP input on port 5555, stop your containe
 
   $ docker run --link mongo --link elasticsearch \
       -p 9000:9000 -p 12201:12201 -p 514:514 -p 5555:5555 \
-      -e GRAYLOG_HTTP_BIND_ADDRESS="http://127.0.0.1:9000/api" \
+      -e GRAYLOG_HTTP_BIND_ADDRESS="127.0.0.1:9000" \
       -d graylog/graylog:3.0
 
 
@@ -58,7 +58,7 @@ Graylog comes with a default configuration that works out of the box but you hav
 Both settings can be configured via environment variables (also see :ref:`configuration`)::
 
   -e GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
-  -e GRAYLOG_HTTP_BIND_ADDRESS="http://127.0.0.1:9000/api"
+  -e GRAYLOG_HTTP_BIND_ADDRESS="127.0.0.1:9000"
 
 In this case you can login to Graylog with the username and password ``admin``.
 
@@ -97,7 +97,7 @@ Example::
         - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
         # Password: admin
         - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
-        - GRAYLOG_HTTP_BIND_ADDRESS=http://127.0.0.1:9000/api
+        - GRAYLOG_HTTP_BIND_ADDRESS=127.0.0.1:9000
       links:
         - mongodb:mongo
         - elasticsearch
@@ -229,7 +229,7 @@ Using Docker volumes for the data of MongoDB, Elasticsearch, and Graylog, the ``
         - GRAYLOG_PASSWORD_SECRET=somepasswordpepper
         # Password: admin
         - GRAYLOG_ROOT_PASSWORD_SHA2=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
-        - GRAYLOG_HTTP_BIND_ADDRESS=http://127.0.0.1:9000/api
+        - GRAYLOG_HTTP_BIND_ADDRESS=127.0.0.1:9000
       links:
         - mongodb:mongo
         - elasticsearch
@@ -347,5 +347,5 @@ The pre-releases are tagged in the `graylog/graylog`_ Docker image.
 Follow the `documentation for the Graylog image on Docker Hub <https://hub.docker.com/r/graylog/graylog/>`__ and pick an alpha/beta/rc tag like this::
 
   $ docker run --link mongo --link elasticsearch -p 9000:9000 -p 12201:12201 -p 514:514 \
-      -e GRAYLOG_HTTP_BIND_ADDRESS="http://127.0.0.1:9000/api" \
+      -e GRAYLOG_HTTP_BIND_ADDRESS="127.0.0.1:9000" \
       -d graylog/graylog:3.0.0-beta.3-1


### PR DESCRIPTION
Update value for GRAYLOG_HTTP_BIND_ADDRESS to remove protocol and path for change from version 2.5 to version 3.0 which corrects error of graylog not starting show a stack trace with message: 

`Caused by: java.lang.IllegalArgumentException: Possible bracketless IPv6 literal: http://127.0.0.1:9000/api`

See this link where it was discussed: https://community.graylog.org/t/possible-bracketless-ipv6-literal-graylog-3-0/8516

Example stack trace:
```
2019-02-16 23:57:00,021 ERROR: org.graylog2.bootstrap.CmdLineTool - Invalid configuration
graylog_1        | com.github.joschi.jadconfig.ValidationException: java.lang.IllegalArgumentException: Possible bracketless IPv6 literal: http://127.0.0.1:9000/api
graylog_1        |      at org.graylog2.configuration.HttpConfiguration.validateHttpBindAddress(HttpConfiguration.java:227) ~[graylog.jar:?]
graylog_1        |      at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_181]
graylog_1        |      at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_181]
graylog_1        |      at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_181]
graylog_1        |      at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_181]
graylog_1        |      at com.github.joschi.jadconfig.ReflectionUtils.invokeMethodsWithAnnotation(ReflectionUtils.java:53) ~[graylog.jar:?]
graylog_1        |      at com.github.joschi.jadconfig.JadConfig.invokeValidatorMethods(JadConfig.java:221) ~[graylog.jar:?]
graylog_1        |      at com.github.joschi.jadconfig.JadConfig.process(JadConfig.java:100) ~[graylog.jar:?]
graylog_1        |      at org.graylog2.bootstrap.CmdLineTool.processConfiguration(CmdLineTool.java:351) [graylog.jar:?]
graylog_1        |      at org.graylog2.bootstrap.CmdLineTool.readConfiguration(CmdLineTool.java:344) [graylog.jar:?]
graylog_1        |      at org.graylog2.bootstrap.CmdLineTool.run(CmdLineTool.java:178) [graylog.jar:?]
graylog_1        |      at org.graylog2.bootstrap.Main.main(Main.java:50) [graylog.jar:?]
graylog_1        | Caused by: java.lang.IllegalArgumentException: Possible bracketless IPv6 literal: http://127.0.0.1:9000/api
graylog_1        |      at com.google.common.base.Preconditions.checkArgument(Preconditions.java:216) ~[graylog.jar:?]
graylog_1        |      at com.google.common.net.HostAndPort.requireBracketsForIPv6(HostAndPort.java:275) ~[graylog.jar:?]
graylog_1        |      at org.graylog2.configuration.HttpConfiguration.getHttpBindAddress(HttpConfiguration.java:88) ~[graylog.jar:?]
graylog_1        |      at org.graylog2.configuration.HttpConfiguration.validateHttpBindAddress(HttpConfiguration.java:222) ~[graylog.jar:?]
graylog_1        |      ... 11 more
```