### PR TITLE
Typo in plugin directory name

### DIFF
--- a/pages/plugins.rst
+++ b/pages/plugins.rst
@@ -247,7 +247,7 @@ Installing and loading plugins
 ==============================
 
 The only thing you need to do to run the plugin in Graylog is to copy the ``.jar`` file to your plugins folder that is configured in your
-``graylog.conf``. The default is just ``plugins/`` relative from your ``graylog-server`` directory.
+``graylog.conf``. The default is just ``plugin/`` relative from your ``graylog-server`` directory.
 
 This is a list of default plugin locations for the different installation methods.
 


### PR DESCRIPTION
The documents says ``plugins/`` is the default directory when it should be ``plugin/`` (without the 's')