### PR TITLE
Document breaking change in grouping in ES6

### DIFF
--- a/pages/queries.rst
+++ b/pages/queries.rst
@@ -31,7 +31,11 @@ Messages where the field *type* includes *ssh*::
 
 Messages where the field *type* includes *ssh* or *login*::
 
-  type:(ssh login)
+  type:(ssh OR login)
+
+.. note:: Elasticsearch 2.x and 5.x split queries on whitespace, so the query ``type:(ssh login)`` was equivalent to ``type:(ssh OR login)``.
+  This is no longer the case in `Elasticsearch 6.0 <https://www.elastic.co/guide/en/elasticsearch/reference/6.6/breaking-changes-6.0.html#_changes_to_queries>`__
+  and you must now include an ``OR`` operator between each term.
 
 Messages where the field *type* includes the exact phrase *ssh login*::
 

--- a/pages/queries.rst
+++ b/pages/queries.rst
@@ -57,7 +57,6 @@ Messages that match regular expression ``ethernet[0-9]+``::
 
 .. note:: Please refer to the Elasticsearch documentation about the `Regular expression syntax <https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-regexp-query.html#regexp-syntax>`_ for details about the supported regular expression dialect.
 
-.. note:: Elasticsearch 2.x allows to use ``_missing_:type`` instead of ``NOT _exists_:type``. This query syntax has been removed in `Elasticsearch 5.0 <https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_search_changes.html#_deprecated_queries_removed>`__.
 
 By default all terms or phrases are OR connected so all messages that have at least one hit are returned. You can use
 **Boolean operators and groups** for control over this::

--- a/pages/upgrade/graylog-2.5.rst
+++ b/pages/upgrade/graylog-2.5.rst
@@ -20,7 +20,7 @@ If you are using the Graylog Sidecar, you either have to use Graylog version 2.5
 Elasticsearch 6 changes
 =======================
 
-There is a breaking change in Elasticsearch 6 that may affect some queries on your searches and dashboards::
+There is a breaking change in Elasticsearch 6 that may affect some queries on your searches and dashboards:
 
 Before Elasticsearch 6, queries for keyword fields were split by whitespaces and combined with ``OR`` operators
 resulting, for example, in ``type:(ssh login)`` and ``type:(ssh OR login)`` being equivalent. This is no longer

--- a/pages/upgrade/graylog-2.5.rst
+++ b/pages/upgrade/graylog-2.5.rst
@@ -16,3 +16,16 @@ Graylog web interface and our plugins, so if you don't use any scripts or 3rd pa
 don't have to do anything else.
 
 If you are using the Graylog Sidecar, you either have to use Graylog version 2.5.1 or update the Sidecar to `version 0.1.7 <https://github.com/Graylog2/collector-sidecar/releases/tag/0.1.7>`_. That version is using the correct CSRF headers for HTTP requests against the Graylog server API.
+
+Elasticsearch 6 changes
+=======================
+
+There is a breaking change in Elasticsearch 6 that may affect some queries on your searches and dashboards::
+
+Before Elasticsearch 6, queries for keyword fields were split by whitespaces and combined with ``OR`` operators
+resulting, for example, in ``type:(ssh login)`` and ``type:(ssh OR login)`` being equivalent. This is no longer
+the case in Elasticsearch 6 and now those queries are different: the former looking for the ``ssh login`` value,
+the second for either ``ssh`` or ``login`` values.
+
+Please ensure to look for those queries in your Graylog setup before upgrading to Elasticsearch 6 and add the
+``OR`` operators where needed.

--- a/pages/upgrade/graylog-3.0.rst
+++ b/pages/upgrade/graylog-3.0.rst
@@ -330,7 +330,7 @@ installed configurations.
 Elasticsearch 6 changes
 =======================
 
-There is a breaking change in Elasticsearch 6 that may affect some queries on your searches and dashboards::
+There is a breaking change in Elasticsearch 6 that may affect some queries on your searches and dashboards:
 
 Before Elasticsearch 6, queries for keyword fields were split by whitespaces and combined with ``OR`` operators
 resulting, for example, in ``type:(ssh login)`` and ``type:(ssh OR login)`` being equivalent. This is no longer

--- a/pages/upgrade/graylog-3.0.rst
+++ b/pages/upgrade/graylog-3.0.rst
@@ -327,3 +327,15 @@ with the following command:
 This command will only remove the content packs, it will not remove the
 installed configurations.
 
+Elasticsearch 6 changes
+=======================
+
+There is a breaking change in Elasticsearch 6 that may affect some queries on your searches and dashboards::
+
+Before Elasticsearch 6, queries for keyword fields were split by whitespaces and combined with ``OR`` operators
+resulting, for example, in ``type:(ssh login)`` and ``type:(ssh OR login)`` being equivalent. This is no longer
+the case in Elasticsearch 6 and now those queries are different: the former looking for the ``ssh login`` value,
+the second for either ``ssh`` or ``login`` values.
+
+Please ensure to look for those queries in your Graylog setup before upgrading to Elasticsearch 6 and add the
+``OR`` operators where needed.


### PR DESCRIPTION
Document Elasticsearch 6 change in grouping keyword searches, where the `split_on_whitespace` has been removed.

Refs https://github.com/Graylog2/graylog2-server/issues/5694

This also needs to be included in the 2.5 documentation.