### PR TITLE
Add note about mongodb username/password escapes

### DIFF
--- a/pages/configuration/server.conf.rst
+++ b/pages/configuration/server.conf.rst
@@ -333,6 +333,7 @@ MongoDB
 * ``mongodb_uri = mongodb://...``
     * MongoDB connection string. Enter your MongoDB connection and authentication information here.
     * See https://docs.mongodb.com/manual/reference/connection-string/ for details.
+    * Take notice that ``+``-signs in the username or password need to be replaced by ``%2B``.
     * Examples:
         - Simple: ``mongodb://localhost/graylog``
         - Authenticate against the MongoDB server: ``mongodb_uri = mongodb://grayloguser:secret@localhost:27017/graylog``


### PR DESCRIPTION
Reflect https://github.com/Graylog2/graylog2-server/pull/5764 in the online documentation.