### PR TITLE
Add bin_dir and data_dir to Report documentation

### DIFF
--- a/pages/reporting/setup.rst
+++ b/pages/reporting/setup.rst
@@ -25,6 +25,10 @@ options in case you need to do some advanced configuration.
 
     * - Name
       - Description
+    * - ``bin_dir``
+      - Directory with binaries needed for PDF generation.
+    * - ``data_dir``
+      - Cache directory for PDF generation.
     * - ``report_disable_sandbox``
       - Disables report generation sandbox.
     * - ``report_generation_timeout_seconds``
@@ -35,6 +39,21 @@ options in case you need to do some advanced configuration.
       - URI to connect to Graylog Web Interface.
     * - ``report_render_engine_port``
       - Port to communicate with background process.
+
+bin_dir
+-------
+Default value: ``bin`` - relative to Graylog working directory
+
+The default distribution comes with two binaries needed for PDF generation 'headless_shell' and 'chromedriver'.
+These binaries are usually located in ``/usr/share/graylog-server/bin``.
+
+data_dir
+--------
+Default value: ``data`` - relative to Graylog working directory
+
+The PDF generation happens on disk in the first place so Graylog needs a place to write out temporary files.
+The system packages create ``/var/lib/graylog-server`` for this purpose. Make sure this directory is correctly configured
+and read-, and writable for the Graylog Server user.
 
 report_disable_sandbox
 ----------------------


### PR DESCRIPTION
Document bin_ and data_dir to fix problems like: https://community.graylog.org/t/reports-not-getting-generated-on-gralog-enterrpose-3-0-0-on-centos-7/9739