### PR TITLE
Refer to correct integrations plugins package

### DIFF
--- a/pages/integrations/inputs/palo_alto_networks_input.rst
+++ b/pages/integrations/inputs/palo_alto_networks_input.rst
@@ -4,7 +4,7 @@
 Palo Alto Networks Input
 ************************
 
-.. note:: This input is available since Graylog version 2.5.0. Installation of an additional ``graylog-integrations-plugin`` package is required. See the :doc:`Integrations Setup <../setup>` page for more info.
+.. note:: This input is available since Graylog version 2.5.0. Installation of an additional ``graylog-integrations-plugins`` package is required. See the :doc:`Integrations Setup <../setup>` page for more info.
 
 This input allows Graylog to receive ``SYSTEM``, ``THREAT`` and ``TRAFFIC`` logs directly from a Palo Alto device
 and the Palo Alto Panorama system. Logs are sent with a typical Syslog header followed by a comma-separated list of fields. The

--- a/pages/integrations/inputs/palo_alto_networks_input.rst
+++ b/pages/integrations/inputs/palo_alto_networks_input.rst
@@ -4,7 +4,7 @@
 Palo Alto Networks Input
 ************************
 
-.. note:: This input is available since Graylog version 2.5.0. Installation of an additional ``graylog-plugin-enterprise-integrations`` package is required. See the :doc:`Integrations Setup <../setup>` page for more info.
+.. note:: This input is available since Graylog version 2.5.0. Installation of an additional ``graylog-integrations-plugin`` package is required. See the :doc:`Integrations Setup <../setup>` page for more info.
 
 This input allows Graylog to receive ``SYSTEM``, ``THREAT`` and ``TRAFFIC`` logs directly from a Palo Alto device
 and the Palo Alto Panorama system. Logs are sent with a typical Syslog header followed by a comma-separated list of fields. The


### PR DESCRIPTION
It wrongly referred to the enterprise version of the integrations, but Palo Alto input is in the open source one.