### PR TITLE
Take care of issues #610(partly), #642, #643

### DIFF
--- a/pages/configuration/backup.rst
+++ b/pages/configuration/backup.rst
@@ -13,7 +13,7 @@ The data within your Elasticsearch Cluster can take the advantage of the `Snapsh
 Disaster recovery
 =================
 
-To be able to restore Graylog after a total System crash you need the Graylog ``server.conf``file - to be exact you need the key you used for ``password_secret`` in the configuration. The second important part is the MongoDB. This database contains all configuration. Possible options how-to `backup MongoDB can be found at the MongoDB documentation <https://docs.mongodb.com/manual/core/backups/#back-up-by-copying-underlying-data-files>`_.
+To be able to restore Graylog after a total System crash you need the Graylog ``server.conf`` file - to be exact you need the key you used for ``password_secret`` in the configuration. The second important part is the MongoDB. This database contains all configuration. Possible options how-to `backup MongoDB can be found at the MongoDB documentation <https://docs.mongodb.com/manual/core/backups/#back-up-by-copying-underlying-data-files>`_.
 
 If you need to restore log data, you can do this using the archiving feature of Graylog enterprise or any other elasticsearch backup and restore option. It is not enough to copy the data directories of your Elasticsearch nodes, you might not be able to restore from that.
 

--- a/pages/gelf.rst
+++ b/pages/gelf.rst
@@ -50,6 +50,8 @@ Prepend the following structure to your GELF message to make it chunked:
 
 All chunks **MUST** arrive within 5 seconds or the server will discard all already arrived and still arriving chunks. A message **MUST NOT** consist of more than 128 chunks.
 
+Please note, that the UDP-Inputs of Graylog use the ``SO_REUSEPORT`` socket option, which was introduced in Linux kernel version 3.9.  
+So be aware, that UDP inputs will **NOT** work on Linux kernel versions prior to 3.9.
 
 Compression
 -----------

--- a/pages/gelf.rst
+++ b/pages/gelf.rst
@@ -50,7 +50,7 @@ Prepend the following structure to your GELF message to make it chunked:
 
 All chunks **MUST** arrive within 5 seconds or the server will discard all already arrived and still arriving chunks. A message **MUST NOT** consist of more than 128 chunks.
 
-Please note, that the UDP-Inputs of Graylog use the ``SO_REUSEPORT`` socket option, which was introduced in Linux kernel version 3.9.  
+.. attention:: Please note, that the UDP-Inputs of Graylog use the ``SO_REUSEPORT`` socket option, which was introduced in Linux kernel version 3.9. 
 So be aware, that UDP inputs will **NOT** work on Linux kernel versions prior to 3.9.
 
 Compression

--- a/pages/gelf.rst
+++ b/pages/gelf.rst
@@ -50,8 +50,7 @@ Prepend the following structure to your GELF message to make it chunked:
 
 All chunks **MUST** arrive within 5 seconds or the server will discard all already arrived and still arriving chunks. A message **MUST NOT** consist of more than 128 chunks.
 
-.. attention:: Please note, that the UDP-Inputs of Graylog use the ``SO_REUSEPORT`` socket option, which was introduced in Linux kernel version 3.9. 
-So be aware, that UDP inputs will **NOT** work on Linux kernel versions prior to 3.9.
+.. attention:: Please note, that the UDP-Inputs of Graylog use the ``SO_REUSEPORT`` socket option, which was introduced in Linux kernel version 3.9. So be aware, that UDP inputs will **NOT** work on Linux kernel versions prior to 3.9.
 
 Compression
 -----------

--- a/pages/sidecar.rst
+++ b/pages/sidecar.rst
@@ -126,7 +126,7 @@ necessary to stop all running instances of NXlog and unconfigure the default sys
     $ sudo /etc/init.d/nxlog stop
     $ sudo update-rc.d -f nxlog remove
     $ sudo gpasswd -a nxlog adm
-    $ sudo chown -R nxlog.nxlog /var/spool/collector-sidecar/nxlog
+    $ sudo chown -R nxlog.nxlog /var/spool/nxlog
 
 
 NXLog on CentOS
@@ -137,7 +137,7 @@ The same on a RedHat based system::
     $ sudo service nxlog stop
     $ sudo chkconfig --del nxlog
     $ sudo gpasswd -a nxlog root
-    $ sudo chown -R nxlog.nxlog /var/spool/collector-sidecar/nxlog
+    $ sudo chown -R nxlog.nxlog /var/spool/nxlog
 
 
 NXlog on Windows


### PR DESCRIPTION
There where 3 issues, which needed a little effort to clean up in the documentation.
The NXLog issue was tested sucessfully with /var/spool/nxlog.  
I suggest, keeping the ``chown`` section, assuring that the file is owned by nxlog but changing the path to the correct version now.
One minor typo was fixed.