### PR TITLE
Corrected list of characters requiring escaping

### DIFF
--- a/pages/queries.rst
+++ b/pages/queries.rst
@@ -133,7 +133,7 @@ Escaping
 
 The following characters must be escaped with a backslash::
 
-  && || : \ / + - ! ( ) { } [ ] ^ " ~ * ?
+  & | : \ / + - ! ( ) { } [ ] ^ " ~ * ?
 
 Example::
 


### PR DESCRIPTION
The list included logical operator strings as opposed to their component characters (eg `||` `&&` vs `|` `&`).