### PR TITLE
Adding changelog for views in 3.1.

### DIFF
--- a/pages/changelog.rst
+++ b/pages/changelog.rst
@@ -2,6 +2,17 @@
 Changelog
 *********
 
+Graylog 3.1.0
+=============
+
+Released: 2019-xx-xx
+
+**Views & Extended Search**
+
+- This feature was partially (everything besides support for parameters in queries)  open-sourced in this version. Formerly it was accessible only through the commercial enterprise plugin.
+- The API prefix for the views/extended search endpoints has changed from `/api/plugins/org.graylog.plugins.enterprise/(views|search)` to `/api/views`/`/api/views/search`.
+- The configuration file directive specifying the maximum age of an unreferenced search object before it is purged has changed from `enterprise_search_maximum_search_age` to `views_maximum_search_age`.
+
 Graylog 3.0.2
 =============
 


### PR DESCRIPTION
This change is starting the changelog for `3.1` by adding a views
section explaining a) the open-sourcing and b) the changed api
endpoints/config directives.