### PR TITLE
Fixing the dpkg command line for 3.1

### DIFF
--- a/pages/installation/os/ubuntu.rst
+++ b/pages/installation/os/ubuntu.rst
@@ -65,7 +65,7 @@ Graylog
 Now install the Graylog repository configuration and Graylog itself with the following commands::
 
     $ wget https://packages.graylog2.org/repo/packages/graylog-3.1-repository_latest.deb
-    $ sudo dpkg -i graylog-3.0-repository_latest.deb
+    $ sudo dpkg -i graylog-3.1-repository_latest.deb
     $ sudo apt-get update && sudo apt-get install graylog-server
 
 Follow the instructions in your ``/etc/graylog/server/server.conf`` and add ``password_secret`` and ``root_password_sha2``. These settings are mandatory and without them, Graylog will not start!


### PR DESCRIPTION
Changed the command so that it works with the file just downloaded for the 3.1 repository, not the 3.0 repository.