### PR TITLE
added official packages to upgrade

### DIFF
--- a/pages/installation.rst
+++ b/pages/installation.rst
@@ -41,4 +41,4 @@ The Graylog server application has the following prerequisites:
 * Oracle Java SE 8 (OpenJDK 8 also works; latest stable update is recommended)
 
 .. caution:: Graylog prior to 2.3 **does not** work with Elasticsearch 5.x!
-.. caution:: Graylog 3 **does not** work with Elasticsearch 7.x!
+.. caution:: Graylog 3.x **does not** work with Elasticsearch 7.x!

--- a/pages/installation/operating_system_packages.rst
+++ b/pages/installation/operating_system_packages.rst
@@ -77,6 +77,8 @@ The update basically works like a fresh installation::
   $ sudo apt-get update
   $ sudo apt-get install graylog-server
 
+.. caution:: If you have the :ref:`Integrations Plugins <integrations_plugins>` or the :ref:`Enterprise Plugins <enterprise_features>` installed, you need to update them together with the Graylog server package. The following command updates all official provided packages by Graylog at the same time: ``sudo apt-get install graylog-server graylog-enterprise-plugins graylog-integrations-plugins graylog-enterprise-integrations-plugins`` 
+
 
 Manual Repository Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -134,6 +136,9 @@ The update basically works like a fresh installation::
   $ sudo yum install graylog-server
 
 Running ``yum clean all`` is required because YUM might use a stale cache and thus might be unable to find the latest version of the ``graylog-server`` package.
+
+.. caution:: If you have the :ref:`Integrations Plugins <integrations_plugins>` or the :ref:`Enterprise Plugins <enterprise_features>` installed, you need to update them together with the Graylog server package. The following command updates all official provided packages by Graylog at the same time: ``sudo yum install graylog-server graylog-enterprise-plugins graylog-integrations-plugins graylog-enterprise-integrations-plugins`` 
+
 
 Manual Repository Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pages/integrations.rst
+++ b/pages/integrations.rst
@@ -1,3 +1,5 @@
+.. _integrations_plugins:
+
 ************
 Integrations
 ************


### PR DESCRIPTION
We have seen several users fail on the update because they missed to update the official installed packages (integrations and enterprise) together with the Graylog server. 
With that note we want to remind people.