### PR TITLE
Update Change Log for release 3.1.1

### DIFF
--- a/pages/changelog.rst
+++ b/pages/changelog.rst
@@ -2,6 +2,22 @@
 Changelog
 *********
 
+Graylog 3.1.1
+=============
+
+Released: 2019-09-04
+
+**Integrations Plugin**
+
+- Add a new `AWS Kinesis/CloudWatch <https://add_docs_link_here>`_ input to Graylog, which guides the user through the setup process and performs checks
+  along the way. It also supports an automated CloudWatch Logs to Kinesis Streams setup which helps to automate much
+  of the complicated manual setup.
+
+**Fixed**
+
+- Error when loading a view. `Graylog2/graylog2-server#6346 <https://github.com/Graylog2/graylog2-server/pull/6346>`_
+- Fix server startup issue resulting from long index name. `Graylog2/graylog2-server#6322 <https://github.com/Graylog2/graylog2-server/issues/6322>`_
+
 Graylog 3.1.0
 =============
 

--- a/pages/enterprise/changelog.rst
+++ b/pages/enterprise/changelog.rst
@@ -2,6 +2,13 @@
 Changelog
 *********
 
+Graylog Enterprise 3.1.1
+========================
+
+Released: 2019-09-04
+
+No changes since 3.1.0.
+
 Graylog Enterprise 3.1.0
 ========================
 


### PR DESCRIPTION
Updates Change Log for release 3.1.1. 

Specifically highlights the new AWS Kinesis/CloudWatch input (link to documentation needed when ready).

Also highlights a few fixes.