### PR TITLE
ifupdown has been replaced by netplan(5) in ova

### DIFF
--- a/pages/installation/virtual_machine_appliances.rst
+++ b/pages/installation/virtual_machine_appliances.rst
@@ -48,7 +48,7 @@ completed:
    
       "Your appliance came up without a configured IP address. Graylog is probably not running correctly!"
    
-   In this case, you have to login and edit ``/etc/network/interfaces`` in order to setup a fixed IP address. Then create the file ``/var/lib/graylog-server/firstboot`` and reboot.
+   In this case, you have to login and edit configuration files under ``/etc/netplan/`` in order to setup a fixed IP address. Then create the file ``/var/lib/graylog-server/firstboot`` and reboot.
 
 
 Logging in


### PR DESCRIPTION
Editing "/etc/network/interfaces" on graylog-3.1.2-1.ova gives "ifupdown has been replaced by netplan(5) on this system.  See /etc/netplan for current configuration"

Virtual Machine Appliance documentation should reflect this.