### PR TITLE
Correct example for route_to_stream function

### DIFF
--- a/pages/pipelines/functions.rst
+++ b/pages/pipelines/functions.rst
@@ -798,10 +798,10 @@ If ``remove_from_default`` is ``true``, the message is also removed from the def
 Example::
 
         // Route the current processed message to a stream with ID `512bad1a535b43bd6f3f5e86` (preferred method)
-        route_to_stream("512bad1a535b43bd6f3f5e86");
+        route_to_stream(id: "512bad1a535b43bd6f3f5e86");
 
         // Route the current processed message to a stream named `Custom Stream`
-        route_to_stream("Custom Stream");
+        route_to_stream(name: "Custom Stream");
 
 remove_from_stream
 ------------------


### PR DESCRIPTION
fixes Graylog2/graylog2-server#6259

The example given for the route_to_stream function doesn't work, at least not for routing by ID. The example for routing by name did work, but I changed it to be more obvious and in line with routing by id.