### PR TITLE
fixed enterprise plugin page

### DIFF
--- a/pages/enterprise/setup.rst
+++ b/pages/enterprise/setup.rst
@@ -56,6 +56,19 @@ The following list shows the minimum required Graylog versions for the Graylog E
       - 2.5.1
     * - 3.0.0
       - 3.0.0
+    * - 3.0.1
+      - 3.0.1
+    * - 3.0.2
+      - 3.0.2
+    * - 3.1.0
+      - 3.1.0
+    * - 3.1.1
+      - 3.1.1
+    * - 3.1.2
+      - 3.1.2
+    * - 3.1.3
+      - 3.1.3
+
 
 Installation
 ============
@@ -111,19 +124,31 @@ If you have done a manual installation you can get the tarball from the download
 
     * - Enterprise Version
       - Download URL
+    * - 3.0.0
+      - :enterprise-plugins-tar:`3.0.0`
+    * - 3.0.1
+      - :enterprise-plugins-tar:`3.0.1`
     * - 3.0.2
       - :enterprise-plugins-tar:`3.0.2`
+    * - 3.1.0
+      - :enterprise-plugins-tar:`3.1.0`
+    * - 3.1.1
+      - :enterprise-plugins-tar:`3.1.1`
+    * - 3.1.2
+      - :enterprise-plugins-tar:`3.1.2`
+    * - 3.1.3
+      - :enterprise-plugins-tar:`3.1.3`
 
 The tarball includes the enterprise plugin JAR file and required binaries that need to be installed.
 
 ::
 
-  $ tar -tzf graylog-enterprise-plugins-3.0.2.tgz
-    graylog-enterprise-plugins-3.0.2/LICENSE
-    graylog-enterprise-plugins-3.0.2/plugin/graylog-plugin-enterprise-3.0.2.jar
-    graylog-enterprise-plugins-3.0.2/bin/headless_shell
-    graylog-enterprise-plugins-3.0.2/bin/chromedriver
-    graylog-enterprise-plugins-3.0.2/bin/chromedriver_start.sh
+  $ tar -tzf graylog-enterprise-plugins-3.1.3.tgz
+    graylog-enterprise-plugins-3.1.3/LICENSE
+    graylog-enterprise-plugins-3.1.3/plugin/graylog-plugin-enterprise-3.1.3.jar
+    graylog-enterprise-plugins-3.1.3/bin/headless_shell
+    graylog-enterprise-plugins-3.1.3/bin/chromedriver
+    graylog-enterprise-plugins-3.1.3/bin/chromedriver_start.sh
 
 
 **JAR file**
@@ -140,10 +165,10 @@ Your plugin directory should look similar to this after installing the enterpris
 ::
 
   plugin/
-  ├── graylog-plugin-aws-3.0.0.jar
-  ├── graylog-plugin-collector-3.0.0.jar
-  ├── graylog-plugin-enterprise-3.0.0.jar
-  └── graylog-plugin-threatintel-3.0.0.jar
+  ├── graylog-plugin-aws-3.1.3.jar
+  ├── graylog-plugin-collector-3.1.3.jar
+  ├── graylog-plugin-enterprise-3.1.3.jar
+  └── graylog-plugin-threatintel-3.1.3.jar
 
 **Binary files**
 
@@ -174,11 +199,11 @@ You should see something like the following in your Graylog server logs. It indi
 
 ::
 
-  2017-12-18T17:39:10.797+01:00 INFO  [CmdLineTool] Loaded plugin: AWS plugins 3.0.0 [org.graylog.aws.plugin.AWSPlugin]
-  2017-12-18T17:39:10.809+01:00 INFO  [CmdLineTool] Loaded plugin: Collector 3.0.0 [org.graylog.plugins.collector.CollectorPlugin]
-  2017-12-18T17:39:10.811+01:00 INFO  [CmdLineTool] Loaded plugin: Enterprise Integration Plugin 3.0.0 [org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin]
-  2017-12-18T17:39:10.805+01:00 INFO  [CmdLineTool] Loaded plugin: Graylog Enterprise 3.0.0 [org.graylog.plugins.enterprise.EnterprisePlugin]
-  2017-12-18T17:39:10.827+01:00 INFO  [CmdLineTool] Loaded plugin: Threat Intelligence Plugin 3.0.0 [org.graylog.plugins.threatintel.ThreatIntelPlugin]
+  2017-12-18T17:39:10.797+01:00 INFO  [CmdLineTool] Loaded plugin: AWS plugins 3.1.3 [org.graylog.aws.plugin.AWSPlugin]
+  2017-12-18T17:39:10.809+01:00 INFO  [CmdLineTool] Loaded plugin: Collector 3.1.3 [org.graylog.plugins.collector.CollectorPlugin]
+  2017-12-18T17:39:10.811+01:00 INFO  [CmdLineTool] Loaded plugin: Enterprise Integration Plugin 3.1.3 [org.graylog.plugins.enterprise_integration.EnterpriseIntegrationPlugin]
+  2017-12-18T17:39:10.805+01:00 INFO  [CmdLineTool] Loaded plugin: Graylog Enterprise 3.1.3 [org.graylog.plugins.enterprise.EnterprisePlugin]
+  2017-12-18T17:39:10.827+01:00 INFO  [CmdLineTool] Loaded plugin: Threat Intelligence Plugin 3.1.3 [org.graylog.plugins.threatintel.ThreatIntelPlugin]
 
 Cluster Setup
 =============


### PR DESCRIPTION
Fixed the Enterprise plugin section. I have added the missing lines about the Graylog > Enterprise Version and more important the missing download links for the tgz for Version 3.0 to 3.1.3
