### PR TITLE
master selection for nomad cluster

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -452,6 +452,13 @@ For a stateful set, the name of the first pod in a cluster always ends with ``-0
 * Verify that the pod name ends in ``-0``
 * Set ``is_master=true`` for this container
 
+Nomad automatic master selection
+================================
+
+Running Graylog in Nomad Cluster opens the same challenge to set ``is_master=true`` only for one node in the cluster. If the container runs on Nomad can be identified with an environmetal check on ``NOMAD_ALLOC_INDEX``. Should the variable be set and is ``0`` the container will set the variable ``is_master=true``. If the variable is set but not 0 it will set ``is_master=false``.
+
+That means, if you run Graylog in a Nomad Cluster it will take care automatically that only one node in the cluster has set ``is_master=true``.
+
 
 Troubleshooting
 ===============

--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -455,7 +455,7 @@ For a stateful set, the name of the first pod in a cluster always ends with ``-0
 Nomad automatic master selection
 ================================
 
-Running Graylog in Nomad Cluster opens the same challenge to set ``is_master=true`` only for one node in the cluster. If the container runs on Nomad can be identified with an environmetal check on ``NOMAD_ALLOC_INDEX``. Should the variable be set and is ``0`` the container will set the variable ``is_master=true``. If the variable is set but not 0 it will set ``is_master=false``.
+Running Graylog in Nomad Cluster opens the same challenge to set ``is_master=true`` only for one node in the cluster. That the container runs on Nomad can be identified with an environmetal check on ``NOMAD_ALLOC_INDEX``. Should the variable be set and is ``0`` the container will set the variable ``is_master=true``. If the variable is set but not ``0 `` it will set ``is_master=false``.
 
 That means, if you run Graylog in a Nomad Cluster it will take care automatically that only one node in the cluster has set ``is_master=true``.
 

--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -455,9 +455,9 @@ For a stateful set, the name of the first pod in a cluster always ends with ``-0
 Nomad automatic master selection
 ================================
 
-Running Graylog in Nomad Cluster opens the same challenge to set ``is_master=true`` only for one node in the cluster. That the container runs on Nomad can be identified with an environmetal check on ``NOMAD_ALLOC_INDEX``. Should the variable be set and is ``0`` the container will set the variable ``is_master=true``. If the variable is set but not ``0 `` it will set ``is_master=false``.
+When running Graylog in a Nomad cluster, you must ensure that only one node in the cluster has the setting ``is_master=true`` in the server.conf file.
 
-That means, if you run Graylog in a Nomad Cluster it will take care automatically that only one node in the cluster has set ``is_master=true``.
+Whether the container is running on Nomad may be identified with an environmetal check on NOMAD_ALLOC_INDEX. Should that variable be set to 0, the container will set Graylog to ``is_master=true``. If the variable is set to anything other than 0 , it will set Graylog to ``is_master=false``.
 
 
 Troubleshooting


### PR DESCRIPTION
After https://github.com/Graylog2/graylog-docker/pull/107/commits/619aca59e2fd78875024e9245e47fcb314295ece is added to the docker image this is the final documentation of this.
