### PR TITLE
Some upgrading 3.2 fixes

### DIFF
--- a/pages/upgrade/graylog-3.2.rst
+++ b/pages/upgrade/graylog-3.2.rst
@@ -52,20 +52,19 @@ For each of the index names returned by the previous command, the following comm
 
 The two steps could also be combined::
 
-  for index in `curl -s localhost:9200/_cat/aliases/*_deflector?h=index`; do curl -s -X PUT --data '{"properties":{"gl2_accounted_message_size":{"type": "long"}}}' -H Content-Type:application/json localhost:9200/$index/_mapping/message ; done'
+  for index in `curl -s localhost:9200/_cat/aliases/*_deflector?h=index`; do curl -s -X PUT --data '{"properties":{"gl2_accounted_message_size":{"type": "long"}}}' -H Content-Type:application/json localhost:9200/$index/_mapping/message ; done
 
 The Graylog servers can now be restarted with the 3.2.0 version.
 
 Known Bugs and Limitations
 ==========================
 
-  * Content Packs containing old Dashbords can not be installed in Graylog 3.2.
-  * Some functionality of the search has been removed, namely:
-    * Retrieving the full query that is sent to Elasticsearch.
-    * Retrieving the list of terms a message field value was indexed with.
-    * The list of indices the current search used to generate results.
-    * The count of all received messages displayed next to the search. We will add the count again, once the calculation works as expected. As a workaround a message count widget can be added to the search.
-  * The "Show surrounding messages" action is not part of 3.2.0, but will be reimplemented in a next version.
+* Some functionality of the search has been removed, namely:
+ * Retrieving the full query that is sent to Elasticsearch.
+ * Retrieving the list of terms a message field value was indexed with.
+ * The list of indices the current search used to generate results.
+ * The count of all received messages displayed next to the search. We will add the count again, once the calculation works as expected. As a workaround a message count widget can be added to the search.
+* The "Show surrounding messages" action is not part of 3.2.0, but will be reimplemented in a next version.
 
 Configuration File Changes
 --------------------------

--- a/pages/upgrade/graylog-3.2.rst
+++ b/pages/upgrade/graylog-3.2.rst
@@ -60,10 +60,12 @@ Known Bugs and Limitations
 ==========================
 
 * Some functionality of the search has been removed, namely:
+
  * Retrieving the full query that is sent to Elasticsearch.
  * Retrieving the list of terms a message field value was indexed with.
  * The list of indices the current search used to generate results.
  * The count of all received messages displayed next to the search. We will add the count again, once the calculation works as expected. As a workaround a message count widget can be added to the search.
+
 * The "Show surrounding messages" action is not part of 3.2.0, but will be reimplemented in a next version.
 
 Configuration File Changes


### PR DESCRIPTION
- Remove trailing quote in mapping change command
- Fix indentation in known bugs and limitations section
- Remove note about content packs and old dashboards
  See: https://github.com/Graylog2/graylog2-server/pull/7321