### PR TITLE
Add explanation for http_publish_uri

### DIFF
--- a/pages/configuration/multinode_setup.rst
+++ b/pages/configuration/multinode_setup.rst
@@ -60,12 +60,14 @@ Graylog Multi-node
 After the installation of Graylog, you should take care that only one Graylog node is configured to be master with the
 configuration setting ``is_master = true``.
 
-The HTTP settings configured in ``http_bind_address`` (or ``http_publish_uri``) must be accessable for all Graylog nodes
-of the cluster.
+The ``http_bind_address`` configured address needs to be reachable by all Graylog nodes in the cluster.
+Same for the ``http_publish_uri`` which is mostly the the ``http_bind_address`` prefixed with the protocol and a closing
+``/``.
 
-This means, if ``http_bind_address`` is set to `0.0.0.0` you **must** set ``http_publish_uri``. ``http_publish_uri`` is
-meant as an access point within the cluster for cluster intern communication. With ``http_bind_address = 0.0.0.0`` the
-node cannot communicate its own IP to the other graylog nodes.
+If the http_bind_address is configured with ``0.0.0.0`` you **must** configure ``http_publish_uri``.
+Otherwise Graylog will use the first non loopback IP, what might not fit into your desired design.
+All Graylog nodes need to reach all other Graylog nodes via their configured ``http_publish_uri`` for inter-node
+communication. If you use TLS in your Graylog configuration, this includes https as protocol.
 
 
 Graylog to MongoDB connection

--- a/pages/configuration/multinode_setup.rst
+++ b/pages/configuration/multinode_setup.rst
@@ -57,9 +57,15 @@ When you secure your Elasticsearch with `User Authentication <https://www.elasti
 Graylog Multi-node
 ==================
 
-After the installation of Graylog, you should take care that only one Graylog node is configured to be master with the configuration setting ``is_master = true``.
+After the installation of Graylog, you should take care that only one Graylog node is configured to be master with the
+configuration setting ``is_master = true``.
 
-The HTTP settings configured in ``http_bind_address`` (or ``http_publish_uri``) must be accessable for all Graylog nodes of the cluster.
+The HTTP settings configured in ``http_bind_address`` (or ``http_publish_uri``) must be accessable for all Graylog nodes
+of the cluster.
+
+This means, if ``http_bind_address`` is set to `0.0.0.0` you **must** set ``http_publish_uri``. ``http_publish_uri`` is
+meant as an access point within the cluster for cluster intern communication. With ``http_bind_address = 0.0.0.0`` the
+node cannot communicate its own IP to the other graylog nodes.
 
 
 Graylog to MongoDB connection

--- a/pages/configuration/multinode_setup.rst
+++ b/pages/configuration/multinode_setup.rst
@@ -61,8 +61,8 @@ After the installation of Graylog, you should take care that only one Graylog no
 configuration setting ``is_master = true``.
 
 The ``http_bind_address`` configured address needs to be reachable by all Graylog nodes in the cluster.
-Same for the ``http_publish_uri`` which is mostly the the ``http_bind_address`` prefixed with the protocol and a closing
-``/``.
+The ``http_publish_uri`` is normally auto-generated from the ``http_bind_address``.
+This URI is used for the inter-node communication.
 
 If the http_bind_address is configured with ``0.0.0.0`` you **must** configure ``http_publish_uri``.
 Otherwise Graylog will use the first non loopback IP, what might not fit into your desired design.


### PR DESCRIPTION
## Description
On multiple occasions users had problems setting up a multi node cluster, because the miss-configured  `http_bind_address` and `http_publish_uri` that of course roots from the really complicated names.

For that i adjusted the documentation.

## Context
https://community.graylog.org/t/node-in-gui-showing-different-values/13735 