### PR TITLE
Squadcast http notification

### DIFF
--- a/pages/alerts.rst
+++ b/pages/alerts.rst
@@ -243,9 +243,9 @@ HTTP alert notification - Supported platforms
 ---------------------------------------------
 
 Squadcast
-    `Squadcast <https://www.squadcast.com>` is an IT Alerting and on-call incident management system, which ingests the alerts from Graylog using the HTTP alert notification method and sends Phone, SMS, Push and Email notifications to the relevant team memners and let them take actions.
+    `Squadcast <https://www.squadcast.com>`__ is an IT Alerting and on-call incident management system, which ingests the alerts from Graylog using the HTTP alert notification method and sends Phone, SMS, Push and Email notifications to the relevant team memners and let them take actions.
 
-    For more information about setting the Graylog - Squadcast integration, please refer the `Squadcast documentaion <https://support.squadcast.com/docs/graylog>`.
+    For more information about setting the Graylog - Squadcast integration, please refer the `Squadcast documentaion <https://support.squadcast.com/docs/graylog>`__.
 
 .. _alert_notification_script:
 

--- a/pages/alerts.rst
+++ b/pages/alerts.rst
@@ -239,6 +239,13 @@ Here is an example of the payload included in a notification::
 
 .. image:: /images/alerts_http_notification.png
 
+HTTP alert notification - Supported platforms
+---------------------------------------------
+
+Squadcast
+    `Squadcast <https://www.squadcast.com>` is an IT Alerting and on-call incident management system, which ingests the alerts from Graylog using the HTTP alert notification method and sends Phone, SMS, Push and Email notifications to the relevant team memners and let them take actions.
+
+    For more information about setting the Graylog - Squadcast integration, please refer the `Squadcast documentaion <https://support.squadcast.com/docs/graylog>`.
 
 .. _alert_notification_script:
 


### PR DESCRIPTION
Added a section for HTTP Notification Alerts which are officially supported by other platforms and added Squadcast as the first entry.

This list can keep growing as more vendors starts supporting it and the documentation can be updated.