### PR TITLE
Reorganize Enterprise Output Framework docs and add BigQuery Output

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -48,6 +48,7 @@ NOTE: There are multiple options for reading this documentation. See link to the
 
    pages/enterprise/intro
    pages/enterprise/setup
+   pages/integrations/output_framework
    pages/archiving
    pages/auditlog
    pages/reporting

--- a/index.rst
+++ b/index.rst
@@ -32,7 +32,6 @@ NOTE: There are multiple options for reading this documentation. See link to the
    pages/geolocation
    pages/indexer_failures
    pages/users_and_roles
-   pages/integrations
    pages/plugins
    pages/content_packs
    pages/external_dashboards
@@ -48,8 +47,13 @@ NOTE: There are multiple options for reading this documentation. See link to the
 
    pages/enterprise/intro
    pages/enterprise/setup
-   pages/integrations/output_framework
    pages/archiving
    pages/auditlog
    pages/reporting
    pages/enterprise/changelog
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Integrations
+   
+   pages/integrations

--- a/index.rst
+++ b/index.rst
@@ -54,6 +54,6 @@ NOTE: There are multiple options for reading this documentation. See link to the
 
 .. toctree::
    :maxdepth: 3
-   :caption: Integrations
+   :caption: Graylog Content
    
    pages/integrations

--- a/pages/integrations.rst
+++ b/pages/integrations.rst
@@ -1,8 +1,8 @@
 .. _integrations_plugins:
 
-************
-Integrations
-************
+********************
+Graylog Integrations
+********************
 
 .. toctree::
    :hidden:

--- a/pages/integrations/output_framework.rst
+++ b/pages/integrations/output_framework.rst
@@ -4,6 +4,7 @@
 Enterprise Output Framework
 ***************************
 
+
 The Enterprise Output Framework provides the ability to forward data from your Graylog 
 cluster to external systems using a variety of network transport methods and payload 
 formats. In addition, you can configure Framework-based Outputs to use 
@@ -14,8 +15,16 @@ outbound messages.
           version 3.3.3, thus an Enterprise license is required. See the 
           :doc:`Integrations Setup <setup>` page for more info.
 
-Enterprise Framework Outputs
-----------------------------
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   output_framework/output_tcp_raw
+   output_framework/output_tcp_syslog
+   output_framework/output_google_bigquery
+
+About the Framework
+-------------------
 
 The Enterprise Output Framework provides a number of new Outputs for various network 
 transport types. All of these Outputs first write messages to an on-disk journal in the 
@@ -98,8 +107,8 @@ CPU cores, available memory, and network bandwidth). Several Output Framework co
 options are available to help you tune performance for your throughput requirements and 
 environment.
 
-General Configuration
-^^^^^^^^^^^^^^^^^^^^^
+Common Configuration
+^^^^^^^^^^^^^^^^^^^^
 
 - ``Title``
    - The name of the Output
@@ -131,11 +140,3 @@ General Configuration
    - The pipeline which will process all messages sent to the Output
 - ``Outbound Payload Format``
    - The format that will be used for outgoing message payloads
-
-.. toctree::
-   :hidden:
-
-   output_framework/output_google_bigquery
-   output_framework/output_tcp_raw
-   output_framework/output_tcp_syslog
-

--- a/pages/integrations/output_framework.rst
+++ b/pages/integrations/output_framework.rst
@@ -4,7 +4,6 @@
 Enterprise Output Framework
 ***************************
 
-
 The Enterprise Output Framework provides the ability to forward data from your Graylog 
 cluster to external systems using a variety of network transport methods and payload 
 formats. In addition, you can configure Framework-based Outputs to use 
@@ -15,13 +14,6 @@ outbound messages.
           version 3.3.3, thus an Enterprise license is required. See the 
           :doc:`Integrations Setup <setup>` page for more info.
 
-.. toctree::
-   :titlesonly:
-   :hidden:
-
-   output_framework/output_tcp_raw
-   output_framework/output_tcp_syslog
-   output_framework/output_google_bigquery
 
 About the Framework
 -------------------
@@ -66,24 +58,6 @@ a processing pipeline which will be executed on each message coming from the sou
 not wish to forward.  It can also be used to add data to modify the contents of the outgoing
 message or to enrich it with additional data.
 
-Outbound Transports
-^^^^^^^^^^^^^^^^^^^
-
-Outbound Transport is the configuration of how the message is sent over the wire:
-
-- ``Enterprise STDOUT Output``
-    - Formatted messages will be displayed on the system's console.  This is included primarily as a debugging tool for pipeline changes.
-- ``Enterprise TCP Raw/Plaintext Output``
-    - Formatted messages will be sent as UTF-8 encoded plain text to the configured TCP endpoint (IP address and port). 
-    - :doc:`Output details<output_framework/output_tcp_raw>`
-- ``Enterprise TCP Syslog Output``
-    - Formatted messages will be sent as the ``MSG`` portion of a standard Syslog message per section 6.4 of the `Syslog specification <https://tools.ietf.org/html/rfc5424>`_.  The Syslog message will be sent to the configured TCP endpoint (IP address and port). 
-    - :doc:`Output details<output_framework/output_tcp_syslog>`
-- ``Enterprise Google Cloud BigQuery Output``
-    - The Output Framework will convert the message's key-value pairs into a new row for insertion into the specified Google BigQuery table. 
-    - :doc:`Output details<output_framework/output_google_bigquery>`
-
-
 Outbound Payload Formatting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -96,6 +70,27 @@ formatting options include:
     -  The Output Framework will expect your pipeline to generate the outgoing payload and store it in the ``pipeline_output`` field of the message.  This can be accomplished in the pipeline by using the ``set_field`` :doc:`built-in function<../pipelines/functions>`.
 - ``No-op Formatter``
     - No payload will be generated from the message.  This formatter is currently only intended for use with the ``Google Cloud BigQuery`` output.  If used with any other Output, the Output payloads will be empty.
+
+
+Framework Outputs
+-----------------
+- :doc:`Enterprise TCP Raw/Plaintext Output<output_framework/output_tcp_raw>`
+    - Formatted messages will be sent as UTF-8 encoded plain text to the configured TCP endpoint (IP address and port). 
+- :doc:`Enterprise TCP Syslog Output<output_framework/output_tcp_syslog>`
+    - Formatted messages will be sent as the ``MSG`` portion of a standard Syslog message per section 6.4 of the `Syslog specification <https://tools.ietf.org/html/rfc5424>`_.  The Syslog message will be sent to the configured TCP endpoint (IP address and port). 
+- :doc:`Enterprise Google Cloud BigQuery Output<output_framework/output_google_bigquery>`
+    - The Output Framework will convert the message's key-value pairs into a new row for insertion into the specified Google BigQuery table. 
+- Enterprise STDOUT Output
+    - Formatted messages will be displayed on the system's console.  This is included primarily as a debugging tool for pipeline changes.
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+   
+   output_framework/output_tcp_raw
+   output_framework/output_tcp_syslog
+   output_framework/output_google_bigquery
+
 
 
 Output Configuration

--- a/pages/integrations/output_framework.rst
+++ b/pages/integrations/output_framework.rst
@@ -17,7 +17,7 @@ outbound messages.
 Enterprise Framework Outputs
 ----------------------------
 
-The Enterprise Output Framework provides a number of new Outputs for the various network 
+The Enterprise Output Framework provides a number of new Outputs for various network 
 transport types. All of these Outputs first write messages to an on-disk journal in the 
 Graylog cluster.  Messages stay in the on-disk journal until the Output is able to 
 successfully send the data to the external receiver.
@@ -57,29 +57,36 @@ a processing pipeline which will be executed on each message coming from the sou
 not wish to forward.  It can also be used to add data to modify the contents of the outgoing
 message or to enrich it with additional data.
 
+Outbound Transports
+^^^^^^^^^^^^^^^^^^^
+
+Outbound Transport is the configuration of how the message is sent over the wire:
+
+- ``Enterprise STDOUT``
+    - Formatted messages will be displayed on the system's console.  This is included primarily as a debugging tool for pipeline changes.
+- ``Enterprise TCP Raw/Plaintext``
+    - Formatted messages will be sent as UTF-8 encoded plain text to the configured TCP endpoint (IP address and port). 
+    - :doc:`Output details<output_framework/output_tcp_raw>`
+- ``Enterprise TCP Syslog``
+    - Formatted messages will be sent as the ``MSG`` portion of a standard Syslog message per section 6.4 of the `Syslog specification <https://tools.ietf.org/html/rfc5424>`_.  The Syslog message will be sent to the configured TCP endpoint (IP address and port). 
+    - :doc:`Output details<output_framework/output_tcp_syslog>`
+- ``Enterprise Google Cloud BigQuery``
+    - The Output Framework will convert the message's key-value pairs into a new row for insertion into the specified Google BigQuery table. 
+    - :doc:`Output details<output_framework/output_google_bigquery>`
+
+
 Outbound Payload Formatting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Prior to sending data out over the wire, Graylog must format the outgoing payload. Payload
 formatting options include:
 
-- ``JSON``
+- ``JSON Formatter``
     - The Output Framework will convert the message's key-value pairs into a JSON object.
 - ``Pipeline-Generated``
     -  The Output Framework will expect your pipeline to generate the outgoing payload and store it in the ``pipeline_output`` field of the message.  This can be accomplished in the pipeline by using the ``set_field`` :doc:`built-in function<../pipelines/functions>`.
-
-
-Output Transports
-^^^^^^^^^^^^^^^^^
-
-Output Transport is the configuration of how the message is sent over the wire:
-
-- ``Enterprise STDOUT``
-    - Formatted messages will be displayed on the system's console.  This is included primarily as a debugging tool for pipeline changes.
-- ``Enterprise TCP Raw/Plaintext``
-    - Formatted messages will be sent as UTF-8 encoded plain text to the configured TCP endpoint (IP address and port).
-- ``Enterprise TCP Syslog``
-    - Formatted messages will be sent as the ``MSG`` portion of a standard Syslog message per section 6.4 of the `Syslog specification <https://tools.ietf.org/html/rfc5424>`_.  The Syslog message will be sent to the configured TCP endpoint (IP address and port).
+- ``No-op Formatter``
+    - No payload will be generated from the message.  This formatter is currently only intended for use with the ``Google Cloud BigQuery`` output.  If used with any other Output, the Output payloads will be empty.
 
 
 Output Configuration
@@ -125,29 +132,10 @@ General Configuration
 - ``Outbound Payload Format``
    - The format that will be used for outgoing message payloads
 
+.. toctree::
+   :hidden:
 
-
-TCP Configuration
-^^^^^^^^^^^^^^^^^
-
-- ``Destination IP Address``
-   - The IP address of the system which will receive the messages.
-- ``Destination Port``
-   - The port on which the destination system will listen for messages.
-- ``Frame Delimiting Method``
-   - The method which will be used to separate individual messages  in the stream.
-   - Frame delimiting methods are defined in Sections 3.4.1 and 3.4.2 of `IETF RFC 6587 <https://tools.ietf.org/html/rfc6587>`_.
-      - ``Newline Character`` A newline character will be appended to each message to mark the end of the message. Any newline characters within the message will be escaped prior to sending.
-      - ``Null Character`` A null character will be appended to each message to mark the end of  the message. Any null characters within the message will be escaped prior to sending.
-      - ``Octet Counting`` The length of the message (in bytes) and a space character for separation will be prepended to the message.  The contents of the message will not be altered.
-
-TCP Syslog Configuration
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-- ``Syslog Facility``
-   - A numeric value in the range of 0 - 23 (inclusive)
-   - Defined in `Section 6.2.1 <https://tools.ietf.org/html/rfc5424#section-6.2.1>`_ of the Syslog specification.
-- ``Syslog Severity``
-   - A numeric value in the range of 0 - 7 (inclusive)
-   - Defined in `Section 6.2.1 <https://tools.ietf.org/html/rfc5424#section-6.2.1>`_ of the Syslog specification.
+   output_framework/output_google_bigquery
+   output_framework/output_tcp_raw
+   output_framework/output_tcp_syslog
 

--- a/pages/integrations/output_framework.rst
+++ b/pages/integrations/output_framework.rst
@@ -71,15 +71,15 @@ Outbound Transports
 
 Outbound Transport is the configuration of how the message is sent over the wire:
 
-- ``Enterprise STDOUT``
+- ``Enterprise STDOUT Output``
     - Formatted messages will be displayed on the system's console.  This is included primarily as a debugging tool for pipeline changes.
-- ``Enterprise TCP Raw/Plaintext``
+- ``Enterprise TCP Raw/Plaintext Output``
     - Formatted messages will be sent as UTF-8 encoded plain text to the configured TCP endpoint (IP address and port). 
     - :doc:`Output details<output_framework/output_tcp_raw>`
-- ``Enterprise TCP Syslog``
+- ``Enterprise TCP Syslog Output``
     - Formatted messages will be sent as the ``MSG`` portion of a standard Syslog message per section 6.4 of the `Syslog specification <https://tools.ietf.org/html/rfc5424>`_.  The Syslog message will be sent to the configured TCP endpoint (IP address and port). 
     - :doc:`Output details<output_framework/output_tcp_syslog>`
-- ``Enterprise Google Cloud BigQuery``
+- ``Enterprise Google Cloud BigQuery Output``
     - The Output Framework will convert the message's key-value pairs into a new row for insertion into the specified Google BigQuery table. 
     - :doc:`Output details<output_framework/output_google_bigquery>`
 

--- a/pages/integrations/output_framework/output_google_bigquery.rst
+++ b/pages/integrations/output_framework/output_google_bigquery.rst
@@ -1,8 +1,8 @@
 .. _output_google_bigquery:
 
-***************************************
-Enterprise Google Cloud BigQuery Output
-***************************************
+****************************
+Google Cloud BigQuery Output
+****************************
 
 This Output allows you to send data to your Google Cloud BigQuery tables.  Each message 
 in the stream will be inserted as a new row in the configured BigQuery table.
@@ -84,7 +84,7 @@ BigQuery Configuration
 - ``Table``
    - Output BigQuery Table
 - ``Excluded Fields``
-   - A comma-separated list of fields that will be used as filter which fields are sent to BigQuery
+   - A comma-separated list of fields that will be filtered out when data is sent to BigQuery
 - ``Credentials File Location``
    - Path to the Service Account credentials file
 

--- a/pages/integrations/output_framework/output_google_bigquery.rst
+++ b/pages/integrations/output_framework/output_google_bigquery.rst
@@ -1,0 +1,90 @@
+.. _output_google_bigquery:
+
+***************************************
+Enterprise Google Cloud BigQuery Output
+***************************************
+
+This Output allows you to send data to your Google Cloud BigQuery tables.  Each message 
+in the stream will be inserted as a new row in the configured BigQuery table.
+
+.. note:: This is an Enterprise Integrations feature and is only available since Graylog 
+          version 3.3.6, thus an Enterprise license is required. See the 
+          :doc:`Integrations Setup <../setup>` page for more info.
+          
+Unlike the :doc:`Raw TCP<output_tcp_raw>` and :doc:`TCP Syslog<output_tcp_syslog>` Outputs, 
+which require a payload formatter in order to work, the BigQuery Output does not rely on a 
+payload formatter.  Since the ``Outbound Payload Format`` is required when setting up any 
+Enterprise Framework Output, we have provided a ``No-op Formatter`` specifically for use 
+with the BigQuery Output.
+
+The BigQuery Output uses the key-value pairs in each Graylog message to build a row to 
+be inserted into your BigQuery table with the Graylog message keys mapping to your 
+BigQuery table's columns. Any Graylog message key which does not have a corresponding 
+column in your BigQuery table will be dropped by Google when the insert is performed. 
+You can use a processing pipeline or the ``Excluded Fields`` list in the BigQuery Output 
+configuration to prevent unwanted fields from being included when each row is sent to
+your BigQuery table.
+
+Required Google Cloud Setup
+---------------------------
+
+Prerequisites
+^^^^^^^^^^^^^
+
+In order to use the Google Cloud BigQuery Output, you will need to create and authorize a 
+service account through your Google Cloud console.
+
+It is assumed that you already have a working Google Cloud account and access to the console.
+
+Create Service Account
+^^^^^^^^^^^^^^^^^^^^^^
+
+1) Log in to the `Google Cloud console <https://console.cloud.google.com>`_
+2) Navigate to ``IAM & Admin`` in the left-hand menu
+3) Select ``Service Accounts`` in the left-hand menu
+4) Select ``+ CREATE SERVICE ACCOUNT`` in the top of the right-hand pane
+5) Create the new service account
+
+   a) Provide a name for the service account (i.e. "Graylog Data")
+   b) Enter a description for the service account
+   c) Click the ``CREATE`` button
+   d) Select appropriate permissions for the new service account.  At a minimum, the service 
+      account will need the ability to write to your BigQuery table
+   e) Click the ''CONTINUE'' button
+   f) If desired, grant other users access to the service account
+   g) Click the ''DONE'' button to finish service account creation
+
+Generate and Download Service Account Credentials
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1) Click on the newly created service account in your list of service accounts
+2) In the ``Keys`` section, select ``Create new key`` from the ``ADD KEY`` drop-down menu
+3) Select ``JSON`` as the key type
+4) Click on the ``CREATE`` button
+5) Save the generated JSON file
+6) Copy the downloaded JSON credentials file to your Graylog host(s).  We strongly 
+   recommend that you take appropriate steps to protect the credentials file (e.g.
+   assigning ownership of the file to the account which runs your Graylog server and 
+   setting file permissions to 400).
+   
+Output Configuration
+--------------------
+
+The Google Cloud BigQuery Output supports all of the standard Enterprise Output Framework 
+`configuration options <../output_framework.html#general-configuration>`__.
+
+
+BigQuery Configuration
+^^^^^^^^^^^^^^^^^^^^^^
+
+- ``Project ID``
+   - Google Cloud Project ID
+- ``Dataset``
+   - Output BigQuery Dataset
+- ``Table``
+   - Output BigQuery Table
+- ``Excluded Fields``
+   - A comma-separated list of fields that will be used as filter which fields are sent to BigQuery
+- ``Credentials File Location``
+   - Path to the Service Account credentials file
+

--- a/pages/integrations/output_framework/output_google_bigquery.rst
+++ b/pages/integrations/output_framework/output_google_bigquery.rst
@@ -1,8 +1,8 @@
 .. _output_google_bigquery:
 
-****************************
-Google Cloud BigQuery Output
-****************************
+***************************************
+Enterprise Google Cloud BigQuery Output
+***************************************
 
 This Output allows you to send data to your Google Cloud BigQuery tables.  Each message 
 in the stream will be inserted as a new row in the configured BigQuery table.
@@ -62,7 +62,8 @@ Generate and Download Service Account Credentials
 3) Select ``JSON`` as the key type
 4) Click on the ``CREATE`` button
 5) Save the generated JSON file
-6) Copy the downloaded JSON credentials file to your Graylog host(s).  We strongly 
+6) Copy the downloaded JSON credentials file to your Graylog host(s).  The credentials 
+   file should be stored in the same location on each host.  We strongly 
    recommend that you take appropriate steps to protect the credentials file (e.g.
    assigning ownership of the file to the account which runs your Graylog server and 
    setting file permissions to 400).
@@ -86,5 +87,5 @@ BigQuery Configuration
 - ``Excluded Fields``
    - A comma-separated list of fields that will be filtered out when data is sent to BigQuery
 - ``Credentials File Location``
-   - Path to the Service Account credentials file
+   - Path to the Service Account credentials file located on your Graylog Node(s)
 

--- a/pages/integrations/output_framework/output_tcp_raw.rst
+++ b/pages/integrations/output_framework/output_tcp_raw.rst
@@ -1,11 +1,11 @@
 .. _output_tcp_raw:
 
-************************
-Raw/Plaintext TCP Output
-************************
+***********************************
+Enterprise TCP Raw/Plaintext Output
+***********************************
 
 This Output allows you to send data as UTF-8 encoded text to an arbitrary TCP endpoint 
-(server and port).
+(server and port).  The data will be sent with no additional formatting or encapsulation.
 
 .. note:: This is an Enterprise Integrations feature and is only available since Graylog 
           version 3.3.3, thus an Enterprise license is required. See the 

--- a/pages/integrations/output_framework/output_tcp_raw.rst
+++ b/pages/integrations/output_framework/output_tcp_raw.rst
@@ -1,8 +1,8 @@
 .. _output_tcp_raw:
 
-***********************************
-Enterprise Raw/Plaintext TCP Output
-***********************************
+************************
+Raw/Plaintext TCP Output
+************************
 
 This Output allows you to send data as UTF-8 encoded text to an arbitrary TCP endpoint 
 (server and port).

--- a/pages/integrations/output_framework/output_tcp_raw.rst
+++ b/pages/integrations/output_framework/output_tcp_raw.rst
@@ -1,0 +1,33 @@
+.. _output_tcp_raw:
+
+***********************************
+Enterprise Raw/Plaintext TCP Output
+***********************************
+
+This Output allows you to send data as UTF-8 encoded text to an arbitrary TCP endpoint 
+(server and port).
+
+.. note:: This is an Enterprise Integrations feature and is only available since Graylog 
+          version 3.3.3, thus an Enterprise license is required. See the 
+          :doc:`Integrations Setup <../setup>` page for more info.
+          
+Output Configuration
+--------------------
+
+The Raw/Plaintext TCP Output supports all of the standard Enterprise Output Framework 
+`configuration options <../output_framework.html#general-configuration>`__.
+
+
+TCP Configuration
+^^^^^^^^^^^^^^^^^
+
+- ``Destination IP Address``
+   - The IP address of the system which will receive the messages.
+- ``Destination Port``
+   - The port on which the destination system will listen for messages.
+- ``Frame Delimiting Method``
+   - The method which will be used to separate individual messages  in the stream.
+   - Frame delimiting methods are defined in Sections 3.4.1 and 3.4.2 of `IETF RFC 6587 <https://tools.ietf.org/html/rfc6587>`_.
+      - ``Newline Character`` A newline character will be appended to each message to mark the end of the message. Any newline characters within the message will be escaped prior to sending.
+      - ``Null Character`` A null character will be appended to each message to mark the end of  the message. Any null characters within the message will be escaped prior to sending.
+      - ``Octet Counting`` The length of the message (in bytes) and a space character for separation will be prepended to the message.  The contents of the message will not be altered.

--- a/pages/integrations/output_framework/output_tcp_syslog.rst
+++ b/pages/integrations/output_framework/output_tcp_syslog.rst
@@ -1,8 +1,8 @@
 .. _output_tcp_syslog:
 
-****************************
-Enterprise TCP Syslog Output
-****************************
+*****************
+TCP Syslog Output
+*****************
 
 This Output allows you to send data as UTF-8 encoded text to an arbitrary TCP Syslog 
 receiver.  The formatted payload will be sent as as the ``MSG`` portion of a standard 

--- a/pages/integrations/output_framework/output_tcp_syslog.rst
+++ b/pages/integrations/output_framework/output_tcp_syslog.rst
@@ -1,0 +1,34 @@
+.. _output_tcp_syslog:
+
+****************************
+Enterprise TCP Syslog Output
+****************************
+
+This Output allows you to send data as UTF-8 encoded text to an arbitrary TCP Syslog 
+receiver.  The formatted payload will be sent as as the ``MSG`` portion of a standard 
+Syslog message per section 6.4 of the `Syslog specification <https://tools.ietf.org/html/rfc5424>`_.
+
+.. note:: This is an Enterprise Integrations feature and is only available since Graylog 
+          version 3.3.3, thus an Enterprise license is required. See the 
+          :doc:`Integrations Setup <../setup>` page for more info.
+          
+Output Configuration
+--------------------
+
+The TCP Syslog Output supports all of the standard Enterprise Output Framework 
+`configuration options <../output_framework.html#general-configuration>`__.
+
+TCP Configuration
+^^^^^^^^^^^^^^^^^
+ See: `TCP Configuration <output_tcp_raw.html#tcp-configuration>`__
+
+TCP Syslog Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- ``Syslog Facility``
+   - A numeric value in the range of 0 - 23 (inclusive)
+   - Defined in `Section 6.2.1 <https://tools.ietf.org/html/rfc5424#section-6.2.1>`_ of the Syslog specification.
+- ``Syslog Severity``
+   - A numeric value in the range of 0 - 7 (inclusive)
+   - Defined in `Section 6.2.1 <https://tools.ietf.org/html/rfc5424#section-6.2.1>`_ of the Syslog specification.
+

--- a/pages/integrations/output_framework/output_tcp_syslog.rst
+++ b/pages/integrations/output_framework/output_tcp_syslog.rst
@@ -1,8 +1,8 @@
 .. _output_tcp_syslog:
 
-*****************
-TCP Syslog Output
-*****************
+****************************
+Enterprise TCP Syslog Output
+****************************
 
 This Output allows you to send data as UTF-8 encoded text to an arbitrary TCP Syslog 
 receiver.  The formatted payload will be sent as as the ``MSG`` portion of a standard 


### PR DESCRIPTION
This change splits apart the Enterprise Output Framework documentation from a single monolithic page into a page-per-output approach.  This should make it easier both to read and to maintain.