### PR TITLE
Add Cloudtrail to list of throttled inputs

### DIFF
--- a/pages/sending_data.rst
+++ b/pages/sending_data.rst
@@ -76,6 +76,7 @@ Graylog Inputs that support throttling
 --------------------------------------
 
  * AWS Flow Logs
+ * AWS Cloudtrail
  * AWS Logs
  * CEF AMQP Input
  * CEF Kafka Input


### PR DESCRIPTION
Just another throttled input. Was searching for it but couldn't find it in the docs.