### PR TITLE
Update ES requirements for 4.0.

### DIFF
--- a/pages/installation.rst
+++ b/pages/installation.rst
@@ -1,3 +1,4 @@
+
 .. _installing:
 
 ******************
@@ -35,11 +36,8 @@ System requirements
 The Graylog server application has the following prerequisites:
 
 * Some modern Linux distribution (Debian Linux, Ubuntu Linux, or CentOS recommended)
-* `Elasticsearch 5 or 6 <https://www.elastic.co/downloads/elasticsearch>`_
+* `Elasticsearch 6.8+ or 7 <https://www.elastic.co/downloads/elasticsearch>`_
 * `MongoDB 3.6, 4.0 or 4.2 <https://docs.mongodb.org/manual/administration/install-on-linux/>`_ 
 * Oracle Java SE 8 (OpenJDK 8 also works; latest stable update is recommended)
-
-.. caution:: Graylog prior to 2.3 **does not** work with Elasticsearch 5.x!
-.. caution:: Graylog 3.x **does not** work with Elasticsearch 7.x!
 
 .. hint:: Graylog 3.x does include first compatibility with Java 11 and we welcome people that test this.


### PR DESCRIPTION
Additionally, this change is removing outdated warnings about
incompatibilities of previous versions.