### PR TITLE
Adding ES rolling upgrade notes.

### DIFF
--- a/pages/upgrade.rst
+++ b/pages/upgrade.rst
@@ -49,6 +49,10 @@ Graylog 4.0 is the first release that supports Elasticsearch 7, the upgrade is r
 
 When upgrading from Elasticsearch 6.x to Elasticsearch 7.x, make sure to read the `upgrade guide <https://www.elastic.co/guide/en/elasticsearch/reference/7.x/setup-upgrade.html>`__ provided by Elastic. The Graylog :ref:`Elasticsearch configuration documentation <configuring_es>` contains information about the compatible Elasticsearch version. After the upgrade you must :ref:`rotate the indices once manually <rotate_es_indices>`.
 
+.. note::
+   A note about rolling upgrades for Elasticsearch:
+   Elasticsearch supports rolling upgrades to avoid downtimes during upgrades. Graylog supports rolling upgrades with no restart of any Graylog node for Elasticsearch as long as they are performed *between minor versions*. For more information please see :ref:`Rolling Upgrade Notes <es_rolling_upgrade>`.
+
 .. toctree::
    :titlesonly:
    :glob:

--- a/pages/upgrade.rst
+++ b/pages/upgrade.rst
@@ -58,4 +58,5 @@ When upgrading from Elasticsearch 6.x to Elasticsearch 7.x, make sure to read th
    :glob:
 
    upgrade/elasticsearch*
+   upgrade/rolling_es_upgrade
 

--- a/pages/upgrade/graylog-4.0.rst
+++ b/pages/upgrade/graylog-4.0.rst
@@ -27,5 +27,6 @@ When upgrading Elasticsearch from one major version to another, please read the 
 
 as well as our :ref:`Elasticsearch Upgrade Notes <upgrading-elasticsearch>`.
 
-Please do notice that Graylog does not support rolling upgrades between major versions, while Elasticsearch does. If you are upgrading from one major version of Elasticsearch to another, you need to restart Graylog in order to reinitialize the storage module.
+Please do notice that Graylog does not support rolling upgrades between major versions, while Elasticsearch does. If you are upgrading from one major version of Elasticsearch to another, you need to restart Graylog in order to reinitialize the storage module. A procedure which allows a rolling upgrade of Elasticsearch between two major versions of a multi-node Graylog cluster is outlined :ref:`here <es_rolling_upgrade>`.
+
 

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -12,7 +12,7 @@ Graylog supports rolling upgrades without restarting any Graylog node for Elasti
 
 To avoid message loss in case of a rolling Elasticsearch upgrade which requires the restart of Graylog nodes, please follow this procedure:
 
-1. Temporarily disable ES automatic node discovery if it is used.
+1. Temporarily disable ES :ref:`automatic node discovery <automatic_node_discovery>`_ if it is used.
 2. Mentally split up the Elasticsearch cluster in two groups by designating each Elasticsearch node to group A or B.
 3. Mentally split up the Graylog cluster in two groups by designating each Graylog node to group A or B.
 4. Temporarily configure each Graylog node from group A to use only Elasticsearch nodes from group A and vice versa for group B.

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -16,12 +16,12 @@ To avoid message loss in case of a rolling Elasticsearch upgrade which requires 
 2. Mentally split up the Elasticsearch cluster in two groups by designating each Elasticsearch node to group A or B.
 3. Mentally split up the Graylog cluster in two groups by designating each Graylog node to group A or B.
 4. Temporarily configure each Graylog node from group A to use only Elasticsearch nodes from group A and vice versa for group B.
-5. Shut down Graylog nodes from group B.
+5. Pause message processing on each Graylog node from group B _or_ shut down Graylog nodes from group B.
 6. Upgrade all Elasticsearch nodes from group B.
-7. Start all Graylog nodes from group B.
-8. Shut down Graylog nodes from group A.
+7. Resume message processing on each Graylog node from Group B _or_ start all Graylog nodes from group B.
+8. Pause message processing on each Graylog node from group A _or_ shut down Graylog nodes from group A.
 9. Upgrade all Elasticsearch nodes from group A.
-10. Revert all changes performed in steps 1 and 4.
+10. Revert all changes performed in steps 1, 4 and 8.
 
 Before performing this procedure, please make sure that:
 

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -16,17 +16,27 @@ To avoid message loss in case of a rolling Elasticsearch upgrade which requires 
 2. Mentally split up the Elasticsearch cluster in two groups by designating each Elasticsearch node to group A or B.
 3. Mentally split up the Graylog cluster in two groups by designating each Graylog node to group A or B.
 4. Temporarily configure each Graylog node from group A to use only Elasticsearch nodes from group A and vice versa for group B.
-5. Pause message processing on each Graylog node from group B _or_ shut down Graylog nodes from group B.
+5. :ref:`Pause message processing <pause_message_processing>`_ on each Graylog node from group B _or_ shut down Graylog nodes from group B.
 6. Upgrade all Elasticsearch nodes from group B.
-7. Resume message processing on each Graylog node from Group B _or_ start all Graylog nodes from group B.
-8. Pause message processing on each Graylog node from group A _or_ shut down Graylog nodes from group A.
+7. Restart each Graylog node from Group B for which you have paused message processing in step 5 _or_ start all Graylog nodes from group B which you have shut down in step 5.
+8. :ref:`Pause message processing <pause message_processing>`_ on each Graylog node from group A _or_ shut down Graylog nodes from group A.
 9. Upgrade all Elasticsearch nodes from group A.
-10. Revert all changes performed in steps 1, 4 and 8.
+10. Restart each Graylog node from Group A for which you have paused message processing in stept 8 _or_ start all Graylog nodes from group A which you have shut down in step 8.
+11. Revert all changes performed in steps 1 and 4.
 
 Before performing this procedure, please make sure that:
 
 1. You have at least 2 nodes in each of your Graylog and Elasticsearch clusters.
-2. Temporarily splitting up your clusters still allow you to handle the incoming message load.
+2. Temporarily splitting up your clusters still allows you to handle the incoming message load.
 
 If performed correctly, this procedure allow you to perform a rolling Elasticsearch upgrade between two major versions without any message loss and a minimal amount of time where a subset of your Graylog nodes is down because of a restart.
+
+.. _pause_message_processing:
+
+Pausing Message Processing on Graylog Nodes
+-------------------------------------------
+
+Instead of shutting down individual Graylog nodes, message processing can be paused instead. This has the benefit that all Graylog nodes will continue to accept messages, those nodes on which message processing is disabled will keep in their journal instead of indexing them on Elasticsearch and continue indexing after a restart.
+
+In order to do this, you can pause message processing by going to the web interface of any node, navigate to ``System`` -> ``Nodes``, click on the ``More Actions`` dropdown next to the node you want to pause message processing and click ``Pause message processing``.
 

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -16,12 +16,12 @@ To avoid message loss in case of a rolling Elasticsearch upgrade which requires 
 2. Mentally split up the Elasticsearch cluster in two groups by designating each Elasticsearch node to group A or B.
 3. Mentally split up the Graylog cluster in two groups by designating each Graylog node to group A or B.
 4. Temporarily configure each Graylog node from group A to use only Elasticsearch nodes from group A and vice versa for group B.
-5. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group B _or_ shut down Graylog nodes from group B.
+5. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group B *or* shut down Graylog nodes from group B.
 6. Upgrade all Elasticsearch nodes from group B.
-7. Restart each Graylog node from Group B for which you have paused message processing in step 5 _or_ start all Graylog nodes from group B which you have shut down in step 5.
-8. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group A _or_ shut down Graylog nodes from group A.
+7. Restart each Graylog node from Group B for which you have paused message processing in step 5 *or* start all Graylog nodes from group B which you have shut down in step 5.
+8. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group A *or* shut down Graylog nodes from group A.
 9. Upgrade all Elasticsearch nodes from group A.
-10. Restart each Graylog node from Group A for which you have paused message processing in stept 8 _or_ start all Graylog nodes from group A which you have shut down in step 8.
+10. Restart each Graylog node from Group A for which you have paused message processing in stept 8 *or* start all Graylog nodes from group A which you have shut down in step 8.
 11. Revert all changes performed in steps 1 and 4.
 
 Before performing this procedure, please make sure that:

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -18,10 +18,10 @@ To avoid message loss in case of a rolling Elasticsearch upgrade which requires 
 4. Temporarily configure each Graylog node from group A to use only Elasticsearch nodes from group A and vice versa for group B.
 5. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group B *or* shut down Graylog nodes from group B.
 6. Upgrade all Elasticsearch nodes from group B.
-7. Restart each Graylog node from Group B for which you have paused message processing in step 5 *or* start all Graylog nodes from group B which you have shut down in step 5.
+7. Restart all Graylog nodes from group B.
 8. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group A *or* shut down Graylog nodes from group A.
 9. Upgrade all Elasticsearch nodes from group A.
-10. Restart each Graylog node from Group A for which you have paused message processing in stept 8 *or* start all Graylog nodes from group A which you have shut down in step 8.
+10. Restart all Graylog nodes from group A.
 11. Revert all changes performed in steps 1 and 4.
 
 Before performing this procedure, please make sure that:

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -1,0 +1,32 @@
+.. _es_rolling_upgrade:
+
+***********************************
+Elasticsearch Rolling Upgrade Notes
+***********************************
+
+This page contains a few notes and a recommended procedure to perform a rolling upgrade for a Elasticsearch cluster utilized by Graylog.
+
+Elasticsearch supports rolling upgrades to avoid downtimes during upgrades. Detailed information about the procedures and limitations are provided `here <https://www.elastic.co/guide/en/elasticsearch/reference/master/rolling-upgrades.html>`__.
+
+Graylog supports rolling upgrades without restarting any Graylog node for Elasticsearch upgrades *between minor versions*. While Elasticsearch supports upgrading from e.g. 6.8 to 7.0, Graylog requires a restart when the major version of the Elasticsearch cluster is changed.
+
+To avoid message loss in case of a rolling Elasticsearch upgrade which requires the restart of Graylog nodes, please follow this procedure:
+
+1. Temporarily disable ES automatic node discovery if it is used.
+2. Mentally split up the Elasticsearch cluster in two groups by designating each Elasticsearch node to group A or B.
+3. Mentally split up the Graylog cluster in two groups by designating each Graylog node to group A or B.
+4. Temporarily configure each Graylog node from group A to use only Elasticsearch nodes from group A and vice versa for group B.
+5. Shut down Graylog nodes from group B.
+6. Upgrade all Elasticsearch nodes from group B.
+7. Start all Graylog nodes from group B.
+8. Shut down Graylog nodes from group A.
+9. Upgrade all Elasticsearch nodes from group A.
+10. Revert all changes performed in steps 1 and 4.
+
+Before performing this procedure, please make sure that:
+
+1. You have at least 2 nodes in each of your Graylog and Elasticsearch clusters.
+2. Temporarily splitting up your clusters still allow you to handle the incoming message load.
+
+If performed correctly, this procedure allow you to perform a rolling Elasticsearch upgrade between two major versions without any message loss and a minimal amount of time where a subset of your Graylog nodes is down because of a restart.
+

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -12,14 +12,14 @@ Graylog supports rolling upgrades without restarting any Graylog node for Elasti
 
 To avoid message loss in case of a rolling Elasticsearch upgrade which requires the restart of Graylog nodes, please follow this procedure:
 
-1. Temporarily disable ES :ref:`automatic node discovery <automatic_node_discovery>`_ if it is used.
+1. Temporarily disable ES :ref:`automatic node discovery <automatic_node_discovery>` if it is used.
 2. Mentally split up the Elasticsearch cluster in two groups by designating each Elasticsearch node to group A or B.
 3. Mentally split up the Graylog cluster in two groups by designating each Graylog node to group A or B.
 4. Temporarily configure each Graylog node from group A to use only Elasticsearch nodes from group A and vice versa for group B.
-5. :ref:`Pause message processing <pause_message_processing>`_ on each Graylog node from group B _or_ shut down Graylog nodes from group B.
+5. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group B _or_ shut down Graylog nodes from group B.
 6. Upgrade all Elasticsearch nodes from group B.
 7. Restart each Graylog node from Group B for which you have paused message processing in step 5 _or_ start all Graylog nodes from group B which you have shut down in step 5.
-8. :ref:`Pause message processing <pause message_processing>`_ on each Graylog node from group A _or_ shut down Graylog nodes from group A.
+8. :ref:`Pause message processing <pause_message_processing>` on each Graylog node from group A _or_ shut down Graylog nodes from group A.
 9. Upgrade all Elasticsearch nodes from group A.
 10. Restart each Graylog node from Group A for which you have paused message processing in stept 8 _or_ start all Graylog nodes from group A which you have shut down in step 8.
 11. Revert all changes performed in steps 1 and 4.


### PR DESCRIPTION
This change is adding notes when and how rolling upgrades of the
Elasticsearch cluster are supported and suggests a procedure to be
followed for major version upgrades of the ES cluster without suffering
from message loss.