### PR TITLE
Replace reference to `quick values` with `aggregate`.

### DIFF
--- a/pages/streams.rst
+++ b/pages/streams.rst
@@ -129,7 +129,7 @@ These are a few example use cases for streams:
 
 * Forward a subset of messages to other data analysis or BI systems to reduce their license costs.
 * Monitor exception or error rates in your whole environment and broken down per subsystem.
-* Get a list of all failed SSH logins and use *quick values* to analyze which user names where affected.
+* Get a list of all failed SSH logins and use *aggregate* on the *username* field to analyze which user names where affected.
 * Catch all HTTP POST requests to ``/login`` that were answered with a HTTP 302 and route them into a stream called
   *Successful user logins*. Now get a chart of when users logged in and use *quick values* to get a list of users that performed
   the most logins in the search time frame.


### PR DESCRIPTION
**Note:** This should be cherry-picked into `3.2` and `4.0` as well.

This change is replacing the reference to the `quick values` function
which does not exist in 3.2+ to the `aggregate` function.

Fixes #977.