### PR TITLE
Update docker example for Graylog 4.0

### DIFF
--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -21,15 +21,16 @@ Quick start
 
 If you want to checkout Graylog on your local desktop without any further customization, you can run the following three commands to create the necessary environment::
 
-  $ docker run --name mongo -d mongo:3
+  $ docker run --name mongo -d mongo:4.2
   $ docker run --name elasticsearch \
       -e "http.host=0.0.0.0" \
+      -e "discovery.type=single-node" \
       -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
-      -d docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.10
+      -d docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
   $ docker run --name graylog --link mongo --link elasticsearch \
       -p 9000:9000 -p 12201:12201 -p 1514:1514 \
       -e GRAYLOG_HTTP_EXTERNAL_URI="http://127.0.0.1:9000/" \
-      -d graylog/graylog:3.3
+      -d graylog/graylog:4.0
 
 
 .. warning:: All configuration examples are created to run on the local computer. Should those be used on external servers, adjust ``GRAYLOG_HTTP_EXTERNAL_URI`` and add ``GRAYLOG_HTTP_PUBLISH_URI`` and ``GRAYLOG_HTTP_EXTERNAL_URI`` according to the :ref:`server.conf documentation <web_rest_api_options>`.


### PR DESCRIPTION
Update all component versions in docker example for Graylog 4.0 and its current system requirements.

Additionally in a default Docker Desktop for Windows setup and also in many Linux distributions the elasticsearch image does not start without changing a Kernel setting. Because this is an example for development we can start Elasticsearch with development mode enabled.