### PR TITLE
Replace Travis CI with a GitHub Action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - uses: ammaraskar/sphinx-action@35082eb35b69713fe335801c4d5846a4cc3c91ff

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,13 @@
+name: Graylog Docs
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ammaraskar/sphinx-action@35082eb35b69713fe335801c4d5846a4cc3c91ff
+      with:
+        docs-folder: "."
+        build-command: "sphinx-build -nW -b html -d _build/doctrees . _build/html"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: python
-python:
-  - "3.7"
-install: "pip install -q -r requirements.txt"
-script: sphinx-build -nW -b html -d _build/doctrees . _build/html
-


### PR DESCRIPTION
This PR replaces our usage of Travis CI to run the docs check with GitHub Actions.

We use this one: https://github.com/ammaraskar/sphinx-action

It can automatically add inline comments to PRs when the sphinx build detects issues.