### PR TITLE
Defining sidebar header background color in CSS file instead of config file.

### DIFF
--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -3,6 +3,11 @@
 	max-width: 1000px !important;
 }
 
+/* override sidebar header background */
+.wy-side-nav-search {
+	background-color: #1F1F1F;
+}
+
 /* override logo height */
 .wy-side-nav-search > a img.logo {
 	height: 40px;

--- a/conf.py
+++ b/conf.py
@@ -121,7 +121,6 @@ pygments_style = 'sphinx'
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-  'style_nav_header_background': '#1F1F1F',
   'logo_only': True,
 }
 


### PR DESCRIPTION
## Description
With https://github.com/Graylog2/documentation/pull/1064 we changed the background color of the header, but the config option `style_nav_header_background` is not being applied on the production system. With this PR we want to tests if we can apply this change by defining the background color in the theme override CSS file.

On my dev system I had to add `?v=1` for the theme override CSS file import, but on the production system this was not necessary for similar changes in the past.