### PR TITLE
Hiding company name in header by using CSS (4.0).

### DIFF
--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -12,3 +12,9 @@
 .wy-side-nav-search > a img.logo {
 	height: 40px;
 }
+
+/* hide header text, html_theme_options logo_only has no effect on the production system */
+.wy-side-nav-search > .icon-home {
+	font-size: 0;
+	margin-bottom: 10px;
+}

--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -3,8 +3,8 @@
 	max-width: 1000px !important;
 }
 
-/* override sidebar header background */
-.wy-side-nav-search {
+/* override sidebar header and mobile nav background */
+.wy-side-nav-search, .wy-nav-top {
 	background-color: #1F1F1F;
 }
 

--- a/conf.py
+++ b/conf.py
@@ -120,9 +120,7 @@ pygments_style = 'sphinx'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-  'logo_only': True,
-}
+#html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
## Description

With https://github.com/Graylog2/documentation/pull/1064/files#diff-6e03d3d89630aba3403afea3514a3ac5948e70d1ced091012e56446f614da340R123 we tried to display the company logo in the sidebar header only. Unfortunately the config `html_theme_options` have no effect on the production system.

With this PR we are hiding the company name by using CSS.