### PR TITLE
Hiding company name in header by using CSS (3.3).

### DIFF
--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -3,7 +3,18 @@
 	max-width: 1000px !important;
 }
 
+/* override sidebar header and mobile nav background */
+.wy-side-nav-search, .wy-nav-top {
+	background-color: #1F1F1F;
+}
+
 /* override logo height */
 .wy-side-nav-search > a img.logo {
 	height: 40px;
+}
+
+/* hide header text, html_theme_options logo_only has no effect on the production system */
+.wy-side-nav-search > .icon-home {
+	font-size: 0;
+	margin-bottom: 10px;
 }

--- a/conf.py
+++ b/conf.py
@@ -120,10 +120,7 @@ pygments_style = 'sphinx'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-  'style_nav_header_background': '#1F1F1F',
-  'logo_only': True,
-}
+#html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]


### PR DESCRIPTION
## Description

With https://github.com/Graylog2/documentation/pull/1065 we tried to display the company logo in the sidebar header only. Unfortunately the config `html_theme_options` have no effect on the production system.

With this PR we are hiding the company name by using CSS.