### PR TITLE
O365 documentation update

### DIFF
--- a/pages/integrations/inputs/o365_input.rst
+++ b/pages/integrations/inputs/o365_input.rst
@@ -94,7 +94,7 @@ O365 Content Subscription
    - This determines how often (in minutes) the Input will check for new log data
    - This value cannot be less than 1 (checking every minute)
 - ``Drop DLP logs containing sensitive data``
-   - For each DLP event, O365 emits a summary log with no sensitive data and a detailed log with sensitive data.  When set, this option will cause the detailed logs to be dropped to prevent sensitive data from being stored in Graylog.  This option is only available since Graylog version 4.0.6.
+   - For each DLP event, O365 produces a summary log with no sensitive data and a detailed log with sensitive data.  When set, this option will cause the detailed logs to be dropped to prevent sensitive data from being stored in Graylog.  This option is only available since Graylog version 4.0.6.
 - ``Enable Throttling``
    - If selected, this will enable Graylog to stop reading new data for this Input if the system gets behind on message processing and needs to catch up
 - ``Store Full Message``

--- a/pages/integrations/inputs/o365_input.rst
+++ b/pages/integrations/inputs/o365_input.rst
@@ -93,6 +93,8 @@ O365 Content Subscription
 - ``Polling Interval``
    - This determines how often (in minutes) the Input will check for new log data
    - This value cannot be less than 1 (checking every minute)
+- ``Drop DLP logs containing sensitive data``
+   - For each DLP event, O365 emits a summary log with no sensitive data and a detailed log with sensitive data.  When set, this option will cause the detailed logs to be dropped to prevent sensitive data from being stored in Graylog.  This option is only available since Graylog version 4.0.6.
 - ``Enable Throttling``
    - If selected, this will enable Graylog to stop reading new data for this Input if the system gets behind on message processing and needs to catch up
 - ``Store Full Message``


### PR DESCRIPTION
This change adds documentation of a new flag on the O365 Input.

The new flag is `Drop DLP logs containing sensitive data`:

![Screen Shot 2021-03-16 at 2 34 57 PM](https://user-images.githubusercontent.com/6466251/111362101-caab2f00-8664-11eb-9669-d935f8cb6dd8.png)
