### PR TITLE
Start upgrade notes for 4.1

### DIFF
--- a/pages/upgrade/graylog-4.1.rst
+++ b/pages/upgrade/graylog-4.1.rst
@@ -1,0 +1,32 @@
+**************************
+Upgrading to Graylog 4.1.x
+**************************
+
+.. _upgrade-from-40-to-41:
+
+.. contents:: Overview
+   :depth: 3
+   :backlinks: top
+
+.. warning:: Please make sure to create a MongoDB database backup before starting the upgrade to Graylog 4.1!
+
+Breaking Changes
+================
+
+Changes to the Elasticsearch Support
+------------------------------------
+
+When you have version-probing for the used Elasticsearch version enabled, and Graylog starts up but can not
+connect to ES, the startup stopped immediately with v4.0 and prior. Starting from 4.1 the default behaviour is,
+that Graylog retries connecting with a delay until it can connect to Elasticsearch. See the Elasticsearch
+configuration_ for details.
+
+.. _configuration: https://docs.graylog.org/en/4.1/pages/configuration/elasticsearch.html
+
+Configuration options: ``elasticsearch_version_probe_attempts`` and ``elasticsearch_version_probe_delay``.
+
+Configuration file changes
+--------------------------
+
+The system stats collector has been reimplemented using OSHI instead of SIGAR.
+The configuration option `disable_sigar` has been renamed to `disable_native_system_stats_collector`.


### PR DESCRIPTION
This brings over the current content of [UPGRADING.rst](https://github.com/Graylog2/graylog2-server/blob/61e55f2b9024923233c451278709b0af00aea349/UPGRADING.rst) from the server repo.