### PR TITLE
Type conversion for message field values

### DIFF
--- a/pages/pipelines/rules.rst
+++ b/pages/pipelines/rules.rst
@@ -80,6 +80,8 @@ being used.
 
 By convention, functions that convert types start with the prefix ``to_``.  Please refer to the :doc:`functions` index for a list.
 
+.. note:: Before using the value of a message field, always convert it to the intended type with one of the ``to_`` :doc:`functions`.
+
 Conditions
 ==========
 


### PR DESCRIPTION
Explicit mention that message field values from a message should always be casted before used. This can
be inferred by all the rule examples in the documentation, but is never explicitely stated.
 
While there is a case with strings, where it works without an explicit cast, this is not considered valid
according to an exchange with the Graylog Support (#446984520). Hence we're proposing to add
the following note as clarification/best practice.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

