### PR TITLE
Remove broken legacy Sidecar Collector documentation

### DIFF
--- a/pages/sidecar.rst
+++ b/pages/sidecar.rst
@@ -7,7 +7,6 @@ Graylog Sidecar
 .. note::
  Graylog 3.0 comes with a new Sidecar implementation.
  We still support the old **Collector Sidecars**, which can be found in the ``System / Collectors (legacy)`` menu entry.
- In case you need to configure legacy **Collector Sidecar** please refer to the `Graylog Collector Sidecar documentation </en/2.5/pages/collector_sidecar.html>`_.
  We encourage users to migrate to the new **Sidecar**, which is covered by this document.
 
 **Graylog Sidecar** is a lightweight configuration management system for different log collectors, also called `Backends`.


### PR DESCRIPTION
Fixes #1165 

Removes broken legacy Sidecar Collector documentation link. The version `2.5` Graylog docs are no longer published, so the link no longer works. 

I've removed the link, and I don't see any reason to try and bring back the legacy docs, since the current 3.0+ Sidecar docs provide the migration instructions.