### PR TITLE
change all 'here' links to contextual links

### DIFF
--- a/pages/alerting/alerting-by-example.rst
+++ b/pages/alerting/alerting-by-example.rst
@@ -139,7 +139,7 @@ the attackers are using.
 Since we use an aggregation event here, the message backlog might not be really helpful
 so it is left off.
 The backlog will show all messages within the time range of ``Search within the last`` and
-useing the ``Query`` entered. If you have a good enough query this can still be helpful.
+use the ``Query`` entered. If you have a good enough query this can still be helpful.
 The number input will limit the amount of messages in the backlog.
 
 Summary

--- a/pages/alerting/alerting-by-example.rst
+++ b/pages/alerting/alerting-by-example.rst
@@ -127,8 +127,7 @@ this field is not needed and we go to the next page.
 
 Notifications
 ^^^^^^^^^^^^^
-We want to receive an email when the event got raised. Configuring a notification, will elevate the event to an alert.
-How to setup an email notification is explained :ref:`here <alert_notification>`.
+We want to receive an email when the event is raised. Configuring a :ref:`notification <alert_notification>` will elevate the event to an alert.
 We will therefore select our already defined email notification and set our ``Grace Period``
 to 5 Minutes. If we are target of a brute force attack then we do not want to get an email every
 10 seconds reminding us that we are being attacked. This ``Grace Period`` will only be respected
@@ -138,9 +137,9 @@ the attackers are using.
 .. image:: /images/event-notification.png
 
 Since we use an aggregation event here, the message backlog might not be really helpful
-so I leave it off.
+so it is left off.
 The backlog will show all messages within the time range of ``Search within the last`` and
-use the ``Query`` we entered. If you have a good enough query this can still be helpful.
+useing the ``Query`` entered. If you have a good enough query this can still be helpful.
 The number input will limit the amount of messages in the backlog.
 
 Summary

--- a/pages/getting_started/configure.rst
+++ b/pages/getting_started/configure.rst
@@ -13,7 +13,7 @@ server.conf
 
 The file ``server.conf`` is the Graylog configuration file. The default location for ``server.conf`` is: ``/etc/graylog/server/server.conf``. 
 
-.. note:: All default file locations are listed :ref:`here<default_file_location>`.
+.. note:: Review the list of :ref:`default file locations <default_file_location>`.
 
 * Entries are generally a single line:
     * ``propertyName=propertyValue``

--- a/pages/getting_started/download_install.rst
+++ b/pages/getting_started/download_install.rst
@@ -22,12 +22,12 @@ Most customers use package tools like DEB or RPM to install the Graylog software
 
 Configuration Management
 ^^^^^^^^^^^^^^^^^^^^^^^^
-Customers who prefer to deploy graylog via configuration management tools may do so. Graylog currently supports :ref:`confmgt`.
+Customers who prefer to deploy Graylog via configuration management tools may do so. Graylog currently supports :ref:`confmgt`.
 
 
 Containers
 ^^^^^^^^^^
-Graylog supports Docker for deployment of Graylog, MongoDB and Elasticsearch. Installation and configuration instructions may be found on the :ref:`here` installation page.
+Graylog supports :ref:`Docker <docker>` for deployment of Graylog, MongoDB, and Elasticsearch.
 
 
 Virtual Appliances

--- a/pages/installation/docker.rst
+++ b/pages/installation/docker.rst
@@ -1,4 +1,4 @@
-.. _here:
+.. _docker:
 
 ******
 Docker

--- a/pages/searching/configuration.rst
+++ b/pages/searching/configuration.rst
@@ -45,7 +45,7 @@ ISO 8601 duration Description
 ``P1DT12H``       1 day and 12 hours
 ================= ===========
 
-More details about the format of ISO 8601 durations can be found `here <https://www.iso.org/obp/ui#iso:std:iso:8601:-1:ed-1:v1:en>`_.
+More details about the format of `ISO 8601 durations <https://www.iso.org/obp/ui#iso:std:iso:8601:-1:ed-1:v1:en>`_.
 
 
 Relative time ranges

--- a/pages/sending/json.rst
+++ b/pages/sending/json.rst
@@ -49,5 +49,4 @@ from a list of releases where the field ``state`` has the value ``uploaded``::
 
     $.releases[0].download_count
 
-
-You can `learn more about JSONPath here <http://goessner.net/articles/JsonPath/>`__.
+Stefan Goessner has some `informative posts on JSONPath <http://goessner.net/articles/JsonPath/>`__.

--- a/pages/sidecar.rst
+++ b/pages/sidecar.rst
@@ -24,7 +24,7 @@ On its first run, or when a configuration change has been detected, Sidecar will
 
 Installation
 ============
-You can get .deb and .rpm packages for Graylog Sidecar in our package repository. For Windows, you can download the installer from `here <https://github.com/Graylog2/collector-sidecar/releases>`_.
+You can get .deb and .rpm packages for Graylog Sidecar in our :doc:`package repository <installation/operating_system_packages>`. The Windows installer, along with all packages, are available in `Releases <https://github.com/Graylog2/collector-sidecar/releases>`_.
 
 Please follow the version matrix to pick the right package:
 

--- a/pages/upgrade/graylog-4.0.rst
+++ b/pages/upgrade/graylog-4.0.rst
@@ -36,7 +36,7 @@ When upgrading Elasticsearch from one major version to another, please read the 
 
 And our :ref:`Elasticsearch Upgrade Notes <upgrading-elasticsearch>`.
 
-Please do notice that Graylog does not support rolling upgrades between major versions, while Elasticsearch does. If you are upgrading from one major version of Elasticsearch to another, you need to restart Graylog in order to reinitialize the storage module. A procedure which allows a rolling upgrade of Elasticsearch between two major versions of a multi-node Graylog cluster is outlined :ref:`here <es_rolling_upgrade>`.
+Graylog does not support rolling upgrades between major versions, while Elasticsearch does. If you are upgrading from one major version of Elasticsearch to another, you need to restart Graylog in order to reinitialize the storage module. Review the procedure for a :ref:`rolling upgrade of Elasticsearch <es_rolling_upgrade>` between two major versions of a multi-node Graylog cluster.
 
 LDAP and Active Directory configuration changes
 -----------------------------------------------

--- a/pages/upgrade/rolling_es_upgrade.rst
+++ b/pages/upgrade/rolling_es_upgrade.rst
@@ -6,7 +6,7 @@ Elasticsearch Rolling Upgrade Notes
 
 This page contains a few notes and a recommended procedure to perform a rolling upgrade for a Elasticsearch cluster utilized by Graylog.
 
-Elasticsearch supports rolling upgrades to avoid downtimes during upgrades. Detailed information about the procedures and limitations are provided `here <https://www.elastic.co/guide/en/elasticsearch/reference/master/rolling-upgrades.html>`__.
+Elasticsearch supports `rolling upgrades <https://www.elastic.co/guide/en/elasticsearch/reference/master/rolling-upgrades.html>`__ to avoid downtimes during upgrades.
 
 Graylog supports rolling upgrades without restarting any Graylog node for Elasticsearch upgrades *between minor versions*. While Elasticsearch supports upgrading from e.g. 6.8 to 7.0, Graylog requires a restart when the major version of the Elasticsearch cluster is changed.
 

--- a/pages/users_roles.rst
+++ b/pages/users_roles.rst
@@ -4,4 +4,4 @@
 Users and Roles
 ***************
 
-This page has moved :ref:`here <usersandrolestoc>`.
+This content is now availabe in :ref:`Users and Roles <usersandrolestoc>`.


### PR DESCRIPTION
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

Effort to change all 'here' links to a sentence structure where the linked resource is contextual. Following the [W3C guidelines](https://www.w3.org/QA/Tips/noClickHere) on hypertext copywriting.