### PR TITLE
Fix URLHaus Feed Type indenting

### DIFF
--- a/pages/integrations/lookups/urlhaus.rst
+++ b/pages/integrations/lookups/urlhaus.rst
@@ -45,9 +45,9 @@ Data Adapter Configuration
 - ``Custom Error TTL``
    - Optional custom TTL for caching erroneous results.  If no value is specified, the default value of 5 seconds will be used.
 - ``URLhaus Feed Type``
-	- This determines which URLhaus feed the data adapter will use
-- ``Online URLs`` is the smaller data set and includes only URLs that have been detected to be currently online
-- ``Recently Added URLs`` is the larger data set and includes all URLs added in the last 30 days whether online or offline
+    - This determines which URLhaus feed the data adapter will use
+    - ``Online URLs`` is the smaller data set and includes only URLs that have been detected to be currently online
+    - ``Recently Added URLs`` is the larger data set and includes all URLs added in the last 30 days whether online or offline
 - ``Refresh Interval``
   - Determines how often new data will be fetched.  The minimum refresh interval is 300 seconds (5 minutes) because that is how often the source data can be updated
 - ``Case Insensitive Lookups``


### PR DESCRIPTION
Fix the indenting, which was done improperly by @danotorrey in attempt to fix the PR check failure. https://github.com/Graylog2/documentation/pull/1173#issuecomment-866854748

It looks like Sphinx did not like the varied indent that was originally coded in #1173 

> Warning: Definition list ends without a blank line; unexpected unindent.

I attempted to fix it in https://github.com/Graylog2/documentation/pull/1178/commits/1cd2b0756e3de1a78de02e6b81165d500e05553f, but I actually made the indent correct. 

This was the best I could do to fix it.

![image](https://user-images.githubusercontent.com/3423655/123116443-87e8b800-d406-11eb-8854-8354197315c0.png)