### PR TITLE
Add documentation for ThreatFox adapter

### DIFF
--- a/pages/integrations.rst
+++ b/pages/integrations.rst
@@ -46,8 +46,9 @@ For a comprehensive list of available features included, see our  :ref:`Enterpri
 * :ref:`Script Alert Notification<alert_notification_script>`
 * :ref:`Okta Log Events Input<okta_input>`
 * :ref:`Office 365 Log Events Input<o365_input>`
-* :ref:`URLhaus Malware URL Data Adapter<urlhaus>`
 * :ref:`GreyNoise Enterprise Data Adapter<greynoise__ent_dataadapter>`
+* :ref:`ThreatFox IOC Tracker Data Adapter<lookups_threatfox>`
+* :ref:`URLhaus Malware URL Data Adapter<lookups_urlhaus>`
 
 .. toctree::
    :hidden:
@@ -56,5 +57,6 @@ For a comprehensive list of available features included, see our  :ref:`Enterpri
    integrations/inputs/okta_input
    integrations/output_framework
    integrations/inputs/o365_input
-   integrations/lookups/urlhaus
    integrations/greynoise_dataadapter
+   integrations/lookups/threatfox
+   integrations/lookups/urlhaus

--- a/pages/integrations/lookups/threatfox.rst
+++ b/pages/integrations/lookups/threatfox.rst
@@ -1,0 +1,68 @@
+.. _lookups_threatfox:
+
+**********************************
+ThreatFox IOC Tracker Data Adapter
+**********************************
+
+ThreatFox is a project from `abuse.ch <https://threatfox.abuse.ch>`_ which tracks
+indicators of compromise (IOCs) associated with malware.  This Data Adapter
+supports lookups by the following key types:
+
+* URL
+* Domain
+* IP:port
+* MD5 hash
+* SHA256 hash
+
+When the data adapter is created, the appropriate data set will be downloaded
+and stored in MongoDB.  New data sets will be fetched based on the configured
+``Refresh Interval``.
+
+.. note:: This is a Graylog Enterprise Integrations feature and is only available since
+  Graylog version 4.1.1. A valid Graylog Enterprise license is required.
+
+Sample Lookup Data
+------------------
+
+A lookup for the file hash ``923fa80da84e45636a62f779913559a07420a1c6e21f093d87ddfe04bda683c4``
+might produce the following output::
+
+  {
+    "first_seen_utc": "2021-07-07T17:03:57.000+0000",
+    "ioc_id": "158365",
+    "ioc_value": "923fa80da84e45636a62f779913559a07420a1c6e21f093d87ddfe04bda683c4",
+    "ioc_type": "sha256_hash",
+    "threat_type": "payload",
+    "fk_malware": "win.agent_tesla",
+    "malware_alias": [
+      "AgenTesla",
+      "AgentTesla",
+      "Negasteal"
+    ],
+    "malware_printable": "Agent Tesla",
+    "confidence_level": 50,
+    "reference": "https://twitter.com/RedBeardIOCs/status/1412819661419433988",
+    "tags": [
+      "agenttesla"
+    ],
+    "anonymous": false,
+    "reporter": "Virus_Deck"
+  }
+
+Data Adapter Configuration
+--------------------------
+
+- ``Title``
+   - A short title for the data adapter
+- ``Description``
+   - A description of the data adapter
+- ``Name``
+   - A unique name which will be used to refer to the data adapter
+- ``Custom Error TTL``
+   - Optional custom TTL for caching erroneous results.  If no value is specified, the default value of 5 seconds will be used.
+- ``Include IOCs Older Than 90 Days``
+   - In order to avoid false positives, IOCs older than 90 days should be handled carefully. By default, IOCs older than 90 days will not be included in the Data Adapter's data.  When this option is selected, IOCs older than 90 days will be included.
+- ``Refresh Interval``
+  - Determines how often new data will be fetched.  The minimum refresh interval is 3600 seconds (1 hour) because that is how often the source data is updated.
+- ``Case Insensitive Lookups``
+  - When selected, this will allow the data adapter to perform case insensitive lookups.

--- a/pages/integrations/lookups/urlhaus.rst
+++ b/pages/integrations/lookups/urlhaus.rst
@@ -1,4 +1,4 @@
-.. _urlhaus:
+.. _lookups_urlhaus:
 
 ********************************
 URLhaus Malware URL Data Adapter


### PR DESCRIPTION
This PR adds documentation for the ThreatFox data adapter which is new in 4.1.1.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

